### PR TITLE
vhost-device-gpu: Move Rutabaga initialing to start of backend

### DIFF
--- a/staging/vhost-device-gpu/rutabaga_gfx/ffi/Cargo.lock
+++ b/staging/vhost-device-gpu/rutabaga_gfx/ffi/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "rutabaga_gfx"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rutabaga_gfx_ffi"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "libc",
  "log",

--- a/staging/vhost-device-gpu/rutabaga_gfx/src/rutabaga_core.rs
+++ b/staging/vhost-device-gpu/rutabaga_gfx/src/rutabaga_core.rs
@@ -50,6 +50,12 @@ pub struct RutabagaResource {
     pub size: u64,
     pub mapping: Option<MemoryMapping>,
 }
+// SAFETY: Safe as the structure can be sent to another thread.
+unsafe impl Send for RutabagaResource {}
+
+// SAFETY: Safe as the structure can be shared with another thread as the state
+// is protected with a lock.
+unsafe impl Sync for RutabagaResource {}
 
 /// A RutabagaComponent is a building block of the Virtual Graphics Interface (VGI).  Each component
 /// on it's own is sufficient to virtualize graphics on many Google products.  These components wrap
@@ -58,7 +64,7 @@ pub struct RutabagaResource {
 ///
 /// Most methods return a `RutabagaResult` that indicate the success, failure, or requested data for
 /// the given command.
-pub trait RutabagaComponent {
+pub trait RutabagaComponent: Send + Sync {
     /// Implementations should return the version and size of the given capset_id.  (0, 0) is
     /// returned by default.
     fn get_capset_info(&self, _capset_id: u32) -> (u32, u32) {
@@ -211,7 +217,7 @@ pub trait RutabagaComponent {
     }
 }
 
-pub trait RutabagaContext {
+pub trait RutabagaContext: Send + Sync {
     /// Implementations must return a RutabagaResource given the `resource_create_blob` parameters.
     fn context_create_blob(
         &mut self,

--- a/staging/vhost-device-gpu/src/main.rs
+++ b/staging/vhost-device-gpu/src/main.rs
@@ -20,8 +20,8 @@ use vhost_user_backend::VhostUserDaemon;
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 
 use crate::vhu_gpu::VhostUserGpuBackend;
-//use vhu_gpu::VhostUserGpuBackend;
 use vhost_device_gpu::GpuConfig;
+use crate::virt_gpu::VirtioGpu;
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -56,13 +56,15 @@ impl TryFrom<GpuArgs> for GpuConfig {
 
 fn start_backend(config: GpuConfig) -> Result<()> {
 
-    let handle: JoinHandle<Result<()>> = spawn(move || loop {
+    let handle: JoinHandle<Result<()>> = spawn(move || {
+        let virtio_gpu = VirtioGpu::new();
+
         info!("Starting backend");
         // There isn't much value in complicating code here to return an error from the threads,
         // and so the code uses unwrap() instead. The panic on a thread won't cause trouble to the
         // main() function and should be safe for the daemon.
         let backend = Arc::new(RwLock::new(
-            VhostUserGpuBackend::new(config.clone()).map_err(Error::CouldNotCreateBackend)?,
+            VhostUserGpuBackend::new(config.clone(), virtio_gpu).map_err(Error::CouldNotCreateBackend)?,
         ));
 
         let socket = config.get_socket_path();
@@ -75,6 +77,7 @@ fn start_backend(config: GpuConfig) -> Result<()> {
         .map_err(Error::CouldNotCreateDaemon)?;
 
         daemon.serve(socket).map_err(Error::ServeFailed)?;
+        Ok(())
     });
 
     handle.join().map_err(std::panic::resume_unwind).unwrap()

--- a/staging/vhost-device-gpu/src/virt_gpu.rs
+++ b/staging/vhost-device-gpu/src/virt_gpu.rs
@@ -101,7 +101,7 @@ pub struct VirtioGpu {
 
 impl VirtioGpu {
     fn create_fence_handler(
-        queue_ctl: VringRwLock,
+        //queue_ctl: VringRwLock,
         fence_state: Arc<Mutex<FenceState>>,
         // interrupt_status: Arc<AtomicUsize>,
         // interrupt_evt: EventFd,
@@ -137,12 +137,14 @@ impl VirtioGpu {
                         completed_desc.desc_index
                     );
 
-                    queue_ctl.add_used(completed_desc.desc_index, completed_desc.len).unwrap();
+                    // temporarily comment, we need to understand it's role play in initializing rutabaga
 
-                    queue_ctl
-                        .signal_used_queue()
-                        .map_err(|_| Error::NotificationFailed).unwrap();
-                    debug!("Notification sent");
+                    //queue_ctl.add_used(completed_desc.desc_index, completed_desc.len).unwrap();
+
+                    // queue_ctl
+                    //     .signal_used_queue()
+                    //     .map_err(|_| Error::NotificationFailed).unwrap();
+                    // debug!("Notification sent");
                     // interrupt_status.fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
                     // if let Some(intc) = &intc {
                     //     intc.lock().unwrap().set_irq(irq_line.unwrap());
@@ -161,7 +163,7 @@ impl VirtioGpu {
     }
 
     pub fn new(
-        queue_ctl: &VringRwLock,
+        //queue_ctl: &VringRwLock,
         // interrupt_status: Arc<AtomicUsize>,
         // interrupt_evt: EventFd,
         // intc: Option<Arc<Mutex<Gic>>>,
@@ -195,7 +197,7 @@ impl VirtioGpu {
 
         let fence_state = Arc::new(Mutex::new(Default::default()));
         let fence = Self::create_fence_handler(
-            queue_ctl.clone(),
+            //queue_ctl.clone(),
             fence_state.clone(),
             // interrupt_status,
             // interrupt_evt,


### PR DESCRIPTION
Due to rutabaga structure it does not allow reinitialization of the rutabaga crate, Rutabaga expects that it should be only called once per every virtual machine instance. Hence move the initialization higherup to the start of the backend.