### PR TITLE
Fix GpuCommand::decode reading command from incorect address

### DIFF
--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.10.0"
-source = "git+https://github.com/mtjhrc/vhost.git#a7a589a521361334d30bb14d692abab896adccb8"
+source = "git+https://github.com/mtjhrc/vhost.git?branch=main#a7a589a521361334d30bb14d692abab896adccb8"
 dependencies = [
  "bitflags 2.4.1",
  "libc",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "vhost-user-backend"
 version = "0.13.1"
-source = "git+https://github.com/mtjhrc/vhost.git#a7a589a521361334d30bb14d692abab896adccb8"
+source = "git+https://github.com/mtjhrc/vhost.git?branch=main#a7a589a521361334d30bb14d692abab896adccb8"
 dependencies = [
  "libc",
  "log",

--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -20,8 +20,8 @@ libc = "0.2"
 log = "0.4"
 rutabaga_gfx = { path = "rutabaga_gfx", features = ["virgl_renderer"] }
 thiserror = "1.0"
-vhost = { git = "https://github.com/mtjhrc/vhost.git", features = ["vhost-user-backend"] }
-vhost-user-backend = { package = "vhost-user-backend", git = "https://github.com/mtjhrc/vhost.git" }
+vhost = { git = "https://github.com/mtjhrc/vhost.git", package = "vhost", branch = "main", features = ["vhost-user-backend"] }
+vhost-user-backend = { git = "https://github.com/mtjhrc/vhost.git", package = "vhost-user-backend", branch = "main",  features = ["gpu-set-socket"] }
 virtio-bindings = "0.2.2"
 virtio-queue = "0.11.0"
 vm-memory = "0.14.0"

--- a/staging/vhost-device-gpu/src/protocol.rs
+++ b/staging/vhost-device-gpu/src/protocol.rs
@@ -296,6 +296,19 @@ pub struct virtio_gpu_resp_display_info {
 }
 unsafe impl ByteValued for virtio_gpu_resp_display_info {}
 
+const EDID_BLOB_MAX_SIZE: usize = 1024;
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct virtio_gpu_resp_edid {
+    pub hdr: virtio_gpu_ctrl_hdr,
+    pub size: u32,
+    pub padding: u32,
+    pub edid: [u8; EDID_BLOB_MAX_SIZE],
+}
+
+unsafe impl ByteValued for virtio_gpu_resp_edid {}
+
 /* data passed in the control vq, 3d related */
 
 #[derive(Copy, Clone, Debug, Default, FromBytes, AsBytes)]
@@ -624,7 +637,6 @@ impl fmt::Debug for GpuCommand {
         match self {
             GetDisplayInfo(_info) => f.debug_struct("GetDisplayInfo").finish(),
             GetEdid(_info) => f.debug_struct("GetEdid").finish(),
-
             ResourceCreate2d(_info) => f.debug_struct("ResourceCreate2d").finish(),
             ResourceUnref(_info) => f.debug_struct("ResourceUnref").finish(),
             SetScanout(_info) => f.debug_struct("SetScanout").finish(),
@@ -786,6 +798,10 @@ pub struct GpuResponsePlaneInfo {
 pub enum GpuResponse {
     OkNoData,
     OkDisplayInfo(Vec<(u32, u32, bool)>),
+    OkEdid {
+        /// The EDID display data blob (as specified by VESA)
+        blob: Box<[u8]>,
+    },
     OkCapsetInfo {
         capset_id: u32,
         version: u32,
@@ -893,6 +909,18 @@ impl GpuResponse {
                     .map_err(|_| Error::DescriptorWriteFailed)?;
                 size_of_val(&disp_info)
             }
+            GpuResponse::OkEdid { ref blob } => {
+                let mut edid_info = virtio_gpu_resp_edid {
+                    hdr,
+                    size: blob.len() as u32,
+                    edid: [0; EDID_BLOB_MAX_SIZE],
+                    padding: Default::default(),
+                };
+                edid_info.edid.copy_from_slice(&blob);
+                resp.write_obj(edid_info, desc_addr)
+                    .map_err(|_| Error::DescriptorWriteFailed)?;
+                size_of_val(&edid_info)
+            }
             GpuResponse::OkCapsetInfo {
                 capset_id,
                 version,
@@ -993,6 +1021,7 @@ impl GpuResponse {
         match self {
             GpuResponse::OkNoData => VIRTIO_GPU_RESP_OK_NODATA,
             GpuResponse::OkDisplayInfo(_) => VIRTIO_GPU_RESP_OK_DISPLAY_INFO,
+            GpuResponse::OkEdid { .. } => VIRTIO_GPU_RESP_OK_EDID,
             GpuResponse::OkCapsetInfo { .. } => VIRTIO_GPU_RESP_OK_CAPSET_INFO,
             GpuResponse::OkCapset(_) => VIRTIO_GPU_RESP_OK_CAPSET,
             GpuResponse::OkResourcePlaneInfo { .. } => VIRTIO_GPU_RESP_OK_RESOURCE_PLANE_INFO,

--- a/staging/vhost-device-gpu/src/protocol.rs
+++ b/staging/vhost-device-gpu/src/protocol.rs
@@ -17,7 +17,7 @@ use std::{fmt, io};
 use crate::vhu_gpu::{self, Error};
 use rutabaga_gfx::RutabagaError;
 use thiserror::Error;
-use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
 use zerocopy::{AsBytes, FromBytes};
 
 //use super::super::descriptor_utils::{Reader, Writer};
@@ -675,6 +675,11 @@ impl GpuCommand {
         let hdr = cmd
             .read_obj::<virtio_gpu_ctrl_hdr>(addr)
             .map_err(|_| Error::DescriptorReadFailed)?;
+
+        let addr = addr
+            .checked_add(size_of::<virtio_gpu_ctrl_hdr>() as u64)
+            .ok_or(Error::DescriptorReadFailed)?;
+
         let cmd = match hdr.type_ {
             VIRTIO_GPU_CMD_GET_DISPLAY_INFO => GetDisplayInfo(
                 cmd.read_obj(addr)

--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -148,6 +148,7 @@ impl VhostUserGpuBackend {
                 virtio_gpu.get_edid(self.gpu_backend.as_mut().unwrap(), info.scanout)
             }
             GpuCommand::ResourceCreate2d(info) => {
+                debug!("ResourceCreate2d: {info:?}");
                 let resource_id = info.resource_id;
                 let resource_create_3d = ResourceCreate3D {
                     target: RUTABAGA_PIPE_TEXTURE_2D,

--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
-use log::{debug, error, info, warn};
+use log::{debug, error, info, trace, warn};
 use std::cell::RefCell;
 use std::{
     convert,
@@ -131,6 +131,7 @@ impl VhostUserGpuBackend {
         desc_addr: GuestAddress,
     ) -> VirtioGpuResult {
         virtio_gpu.force_ctx_0();
+        trace!("process_gpu_command: {cmd:?}");
         match cmd {
             GpuCommand::GetDisplayInfo(_) => {
                 let display_info: VirtioGpuRespDisplayInfo = self
@@ -144,18 +145,10 @@ impl VhostUserGpuBackend {
                 Ok(GpuResponse::OkDisplayInfo(virtio_display))
             }
             GpuCommand::GetEdid(info) => {
-                let scanout_id = self
-                    .gpu_backend
-                    .as_mut()
-                    .unwrap()
-                    .get_edid(&info.scanout)
-                    .unwrap();
-                println!("scanout info: {:?}", scanout_id);
-                virtio_gpu.get_edid(info.scanout)
+                virtio_gpu.get_edid(self.gpu_backend.as_mut().unwrap(), info.scanout)
             }
             GpuCommand::ResourceCreate2d(info) => {
                 let resource_id = info.resource_id;
-
                 let resource_create_3d = ResourceCreate3D {
                     target: RUTABAGA_PIPE_TEXTURE_2D,
                     format: info.format,
@@ -680,7 +673,7 @@ impl VhostUserBackendMut for VhostUserGpuBackend {
         Ok(())
     }
 
-    fn set_gpu_socket(&mut self, mut backend: GpuBackend) {
+    fn set_gpu_socket(&mut self, backend: GpuBackend) {
         self.gpu_backend = Some(backend);
     }
     fn get_config(&self, offset: u32, size: u32) -> Vec<u8> {


### PR DESCRIPTION
This fixes the wrong width/height/format etc for ResourceCreate2d.

The layout of the command in memory is a header followed by a command specific struct. We have to shift the address by the header length  when reading the command struct.
