### PR TITLE
Resource attach backing

### DIFF
--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -278,10 +278,10 @@ impl VhostUserGpuBackend {
 
                 virtio_gpu.transfer_read(ctx_id, resource_id, transfer, None)
             }
-            GpuCommand::CmdSubmit3d(info) => {
+            GpuCommand::CmdSubmit3d(_info) => {
                 todo!()
             }
-            GpuCommand::ResourceCreateBlob(info) => {
+            GpuCommand::ResourceCreateBlob(_info) => {
                 todo!()
             }
             // GpuCommand::CmdSubmit3d(info) => {

--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -464,7 +464,7 @@ impl VhostUserGpuBackend {
         virtio_gpu: &mut VirtioGpu,
         vring: &VringRwLock,
     ) -> Result<()> {
-        let mem = self.mem.as_mut().unwrap().memory().into_inner();
+        let mem = self.mem.as_ref().unwrap().memory().into_inner();
         let desc_chains: Vec<_> = vring
             .get_mut()
             .get_queue_mut()

--- a/staging/vhost-device-gpu/src/virt_gpu.rs
+++ b/staging/vhost-device-gpu/src/virt_gpu.rs
@@ -48,6 +48,7 @@ fn sglist_to_rutabaga_iovecs(
     for &(addr, len) in vecs {
         let slice = mem.get_slice(addr, len).unwrap();
         rutabaga_iovecs.push(RutabagaIovec {
+            // TODO: investigate the deprecated method, and it's replacement
             base: slice.as_ptr() as *mut c_void,
             len,
         });


### PR DESCRIPTION
Add support for ResourceAttachBlocking
    
By implementing ResourceAttachBlocking command, TransferToHost2d no longer fails.
This commit removes derive(Copy) from GpuCommand, to be able store non-copy type inside, in our case a Vec.