### PR TITLE
Working scanout output in QEMU + CmdSubmit3d

### DIFF
--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -176,7 +176,6 @@ impl VhostUserGpuBackend {
                     self.gpu_backend.as_mut().unwrap(),
                     gpu_scanout,
                     info.resource_id,
-                    None,
                 )
             }
             GpuCommand::ResourceFlush(info) => virtio_gpu.flush_resource(info.resource_id),

--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -13,7 +13,7 @@ use std::{
 
 use thiserror::Error as ThisError;
 use vhost::vhost_user::gpu_message::{
-    VhostUserGpuCursorPos, VhostUserGpuEdidRequest, VhostUserGpuScanout, VirtioGpuRespDisplayInfo,
+    VhostUserGpuCursorPos, VhostUserGpuEdidRequest, VirtioGpuRespDisplayInfo,
 };
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost::vhost_user::GpuBackend;
@@ -165,19 +165,12 @@ impl VhostUserGpuBackend {
                 virtio_gpu.resource_create_3d(resource_id, resource_create_3d)
             }
             GpuCommand::ResourceUnref(info) => virtio_gpu.unref_resource(info.resource_id),
-            GpuCommand::SetScanout(info) => {
-                debug!("SetScanout: {info:?}");
-                let gpu_scanout: VhostUserGpuScanout = VhostUserGpuScanout {
-                    scanout_id: info.scanout_id,
-                    width: info.r.width,
-                    height: info.r.height,
-                };
-                virtio_gpu.set_scanout(
-                    self.gpu_backend.as_mut().unwrap(),
-                    gpu_scanout,
-                    info.resource_id,
-                )
-            }
+            GpuCommand::SetScanout(info) => virtio_gpu.set_scanout(
+                self.gpu_backend.as_mut().unwrap(),
+                info.scanout_id,
+                info.resource_id,
+                info.r.into(),
+            ),
             GpuCommand::ResourceFlush(info) => virtio_gpu.flush_resource(info.resource_id),
             GpuCommand::TransferToHost2d(info) => {
                 let resource_id = info.resource_id;
@@ -845,6 +838,7 @@ mod tests {
             rutabaga,
             resources: BTreeMap::default(),
             fence_state: Arc::new(Mutex::new(Default::default())),
+            scanouts: Default::default(),
         }
     }
 

--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -290,7 +290,10 @@ impl VhostUserGpuBackend {
 
                 virtio_gpu.transfer_read(ctx_id, resource_id, transfer, None)
             }
-            GpuCommand::CmdSubmit3d(_info) => Ok(GpuResponse::OkNoData),
+            GpuCommand::CmdSubmit3d {
+                fence_ids,
+                mut cmd_data,
+            } => virtio_gpu.submit_command(hdr.ctx_id, &mut cmd_data, &fence_ids),
             GpuCommand::ResourceCreateBlob(_info) => {
                 todo!()
             }
@@ -662,7 +665,7 @@ mod tests {
     };
 
     use self::protocol::{
-        virtio_gpu_cmd_submit, virtio_gpu_ctrl_hdr, virtio_gpu_ctx_create, virtio_gpu_ctx_destroy,
+        virtio_gpu_ctrl_hdr, virtio_gpu_ctx_create, virtio_gpu_ctx_destroy,
         virtio_gpu_ctx_resource, virtio_gpu_get_capset, virtio_gpu_get_capset_info,
         virtio_gpu_resource_assign_uuid, virtio_gpu_resource_attach_backing,
         virtio_gpu_resource_create_2d, virtio_gpu_resource_create_3d,
@@ -940,7 +943,6 @@ mod tests {
             GpuCommand::ResourceFlush(virtio_gpu_resource_flush::default()),
             GpuCommand::GetCapset(virtio_gpu_get_capset::default()),
             GpuCommand::ResourceCreate3d(virtio_gpu_resource_create_3d::default()),
-            GpuCommand::CmdSubmit3d(virtio_gpu_cmd_submit::default()),
         ];
         for cmd in gpu_cmd {
             backend
@@ -971,6 +973,10 @@ mod tests {
                 virtio_gpu_resource_attach_backing::default(),
                 [(GuestAddress(0), 0x1000)].to_vec(),
             ),
+            GpuCommand::CmdSubmit3d {
+                cmd_data: Vec::new(),
+                fence_ids: Vec::new(),
+            },
         ];
         for cmd in gpu_cmd {
             backend

--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -171,7 +171,11 @@ impl VhostUserGpuBackend {
                 info.resource_id,
                 info.r.into(),
             ),
-            GpuCommand::ResourceFlush(info) => virtio_gpu.flush_resource(info.resource_id),
+            GpuCommand::ResourceFlush(info) => virtio_gpu.flush_resource(
+                info.resource_id,
+                self.gpu_backend.as_mut().unwrap(),
+                info.r.into(),
+            ),
             GpuCommand::TransferToHost2d(info) => {
                 let resource_id = info.resource_id;
                 let transfer = Transfer3D::new_2d(info.r.x, info.r.y, info.r.width, info.r.height);
@@ -923,6 +927,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "This test needs to modified to mock GpuBackend"]
     fn test_process_gpu_command() {
         let (mut backend, mem, _) = init();
 

--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -197,7 +197,6 @@ impl VhostUserGpuBackend {
                     cursor_pos,
                     info.hot_x,
                     info.hot_y,
-                    mem,
                 )
             }
             GpuCommand::MoveCursor(info) => {

--- a/staging/vhost-device-gpu/src/vhu_gpu.rs
+++ b/staging/vhost-device-gpu/src/vhu_gpu.rs
@@ -108,7 +108,7 @@ impl VhostUserGpuBackend {
                 events_read: 0.into(),
                 events_clear: 0.into(),
                 num_scanouts: Le32::from(VIRTIO_GPU_MAX_SCANOUTS as u32),
-                num_capsets: 0.into(),
+                num_capsets: RutabagaVirtioGpu::MAX_NUMBER_OF_CAPSETS.into(),
             },
             event_idx: false,
             gpu_backend: None,

--- a/staging/vhost-device-gpu/src/virt_gpu.rs
+++ b/staging/vhost-device-gpu/src/virt_gpu.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 use std::env;
-use std::num::NonZeroU32;
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -25,10 +24,11 @@ use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, VolatileSlice};
 //use super::super::Queue as VirtQueue;
 use super::protocol::GpuResponse::*;
 use super::protocol::{
-    GpuResponse, GpuResponsePlaneInfo, VirtioGpuResult, VIRTIO_GPU_BLOB_FLAG_CREATE_GUEST_HANDLE,
-    VIRTIO_GPU_BLOB_MEM_HOST3D,
+    virtio_gpu_rect, GpuResponse, GpuResponsePlaneInfo, VirtioGpuResult,
+    VIRTIO_GPU_BLOB_FLAG_CREATE_GUEST_HANDLE, VIRTIO_GPU_BLOB_MEM_HOST3D,
 };
 use crate::protocol::VIRTIO_GPU_FLAG_INFO_RING_IDX;
+use crate::virtio_gpu::VIRTIO_GPU_MAX_SCANOUTS;
 use std::result::Result;
 use vhost::vhost_user::GpuBackend;
 
@@ -52,6 +52,25 @@ fn sglist_to_rutabaga_iovecs(
         });
     }
     Ok(rutabaga_iovecs)
+}
+
+#[derive(Default, Debug)]
+pub struct Rectangle {
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl From<virtio_gpu_rect> for Rectangle {
+    fn from(r: virtio_gpu_rect) -> Self {
+        Self {
+            x: r.x,
+            y: r.y,
+            width: r.width,
+            height: r.height,
+        }
+    }
 }
 
 pub trait VirtioGpu {
@@ -130,8 +149,9 @@ pub trait VirtioGpu {
     fn set_scanout(
         &mut self,
         gpu_backend: &mut GpuBackend,
-        gpu_scanout: VhostUserGpuScanout,
+        scanout_id: u32,
         resource_id: u32,
+        rect: Rectangle,
     ) -> VirtioGpuResult;
 
     /// Creates a 3D resource with the given properties and resource_id.
@@ -245,11 +265,27 @@ pub struct FenceState {
     completed_fences: BTreeMap<VirtioGpuRing, u64>,
 }
 
+#[derive(Copy, Clone, Debug, Default)]
+struct AssociatedScanouts(u32);
+
+impl AssociatedScanouts {
+    fn enable(&mut self, scanout_id: u32) {
+        self.0 |= 1 << scanout_id;
+    }
+
+    fn disable(&mut self, scanout_id: u32) {
+        self.0 ^= 1 << scanout_id;
+    }
+}
+
 #[derive(Default)]
 pub struct VirtioGpuResource {
     pub size: u64,
     pub shmem_offset: Option<u64>,
     pub rutabaga_external_mapping: bool,
+    /// Stores information about which scanouts are associated with the given resource.
+    /// Resource could be used for multiple scanouts (the displays are mirrored).
+    scanouts: AssociatedScanouts,
 }
 
 impl VirtioGpuResource {
@@ -260,14 +296,20 @@ impl VirtioGpuResource {
             size,
             shmem_offset: None,
             rutabaga_external_mapping: false,
+            scanouts: Default::default(),
         }
     }
+}
+
+pub struct VirtioGpuScanout {
+    resource_id: u32,
 }
 
 pub struct RutabagaVirtioGpu {
     pub(crate) rutabaga: Rutabaga,
     pub(crate) resources: BTreeMap<u32, VirtioGpuResource>,
     pub(crate) fence_state: Arc<Mutex<FenceState>>,
+    pub(crate) scanouts: [Option<VirtioGpuScanout>; VIRTIO_GPU_MAX_SCANOUTS],
 }
 
 impl RutabagaVirtioGpu {
@@ -387,6 +429,7 @@ impl RutabagaVirtioGpu {
             rutabaga,
             resources: Default::default(),
             fence_state,
+            scanouts: Default::default(),
         }
     }
 
@@ -444,37 +487,65 @@ impl VirtioGpu for RutabagaVirtioGpu {
     fn set_scanout(
         &mut self,
         gpu_backend: &mut GpuBackend,
-        gpu_scanout: VhostUserGpuScanout,
+        scanout_id: u32,
         resource_id: u32,
+        rect: Rectangle,
     ) -> VirtioGpuResult {
-        gpu_backend.set_scanout(&gpu_scanout).map_err(|e| {
-            error!("Failed to set scanout from frontend: {}", e);
-            ErrUnspec
-        })?;
+        let scanout = self
+            .scanouts
+            .get_mut(scanout_id as usize)
+            .ok_or(ErrInvalidScanoutId)?;
+
+        // If a resource is already associated with this scanout, make sure to disable this scanout for that resource
+        if let Some(resource_id) = scanout.as_ref().map(|scanout| scanout.resource_id) {
+            let resource = self
+                .resources
+                .get_mut(&resource_id)
+                .ok_or(ErrInvalidResourceId)?;
+
+            resource.scanouts.disable(scanout_id);
+        }
 
         // Virtio spec: "The driver can use resource_id = 0 to disable a scanout."
         if resource_id == 0 {
-            error!("NOT IMPLEMENTED: disable scanout");
+            *scanout = None;
+            debug!("Disabling scanout scanout_id={scanout_id}");
+            gpu_backend
+                .set_scanout(&VhostUserGpuScanout {
+                    scanout_id,
+                    width: 0,
+                    height: 0,
+                })
+                .map_err(|e| {
+                    error!("Failed to set_scanout: {e:?}");
+                    ErrUnspec
+                })?;
             return Ok(OkNoData);
         }
 
-        let _resource = self
+        debug!("Enabling scanout scanout_id={scanout_id}, resource_id={resource_id}: {rect:?}");
+
+        // QEMU doesn't like (it lags) when we call set_scanout while the scanout is enabled
+        if scanout.is_none() {
+            gpu_backend
+                .set_scanout(&VhostUserGpuScanout {
+                    scanout_id,
+                    width: rect.width,
+                    height: rect.height,
+                })
+                .map_err(|e| {
+                    error!("Failed to set_scanout: {e:?}");
+                    ErrUnspec
+                })?;
+        }
+
+        let resource = self
             .resources
             .get_mut(&resource_id)
             .ok_or(ErrInvalidResourceId)?;
 
-        //todo:
-        //create a display surface
-
-        // `resource_id` has already been verified to be non-zero
-        let resource_id = match NonZeroU32::new(resource_id) {
-            Some(id) => id,
-            None => return Ok(OkNoData),
-        };
-        //todo:
-        //store resource_id in a struct that will be used later
-        debug!("resource id: {:?}", resource_id);
-
+        resource.scanouts.enable(scanout_id);
+        *scanout = Some(VirtioGpuScanout { resource_id });
         Ok(OkNoData)
     }
 
@@ -848,6 +919,7 @@ mod tests {
             rutabaga,
             resources: Default::default(),
             fence_state: Arc::new(Mutex::new(Default::default())),
+            scanouts: Default::default(),
         }
     }
 

--- a/staging/vhost-device-gpu/src/virt_gpu.rs
+++ b/staging/vhost-device-gpu/src/virt_gpu.rs
@@ -11,6 +11,7 @@ use log::{debug, error, trace};
 use rutabaga_gfx::{
     ResourceCreate3D, ResourceCreateBlob, Rutabaga, RutabagaBuilder, RutabagaChannel,
     RutabagaFence, RutabagaFenceHandler, RutabagaIovec, RutabagaResult, Transfer3D,
+    RUTABAGA_CAPSET_DRM, RUTABAGA_CAPSET_VENUS, RUTABAGA_CAPSET_VIRGL, RUTABAGA_CAPSET_VIRGL2,
     RUTABAGA_CHANNEL_TYPE_WAYLAND, RUTABAGA_MAP_ACCESS_MASK, RUTABAGA_MAP_ACCESS_READ,
     RUTABAGA_MAP_ACCESS_RW, RUTABAGA_MAP_ACCESS_WRITE, RUTABAGA_MAP_CACHE_MASK,
     RUTABAGA_MEM_HANDLE_TYPE_OPAQUE_FD,
@@ -417,13 +418,19 @@ impl RutabagaVirtioGpu {
             channel_type: RUTABAGA_CHANNEL_TYPE_WAYLAND,
         }];
         let rutabaga_channels_opt = Some(rutabaga_channels);
-
-        let builder = RutabagaBuilder::new(rutabaga_gfx::RutabagaComponentType::VirglRenderer, 0)
-            .set_rutabaga_channels(rutabaga_channels_opt)
-            .set_use_egl(true)
-            .set_use_gles(true)
-            .set_use_glx(true)
-            .set_use_surfaceless(true);
+        let builder = RutabagaBuilder::new(
+            rutabaga_gfx::RutabagaComponentType::VirglRenderer,
+            (RUTABAGA_CAPSET_VIRGL
+                | RUTABAGA_CAPSET_VIRGL2
+                | RUTABAGA_CAPSET_DRM
+                | RUTABAGA_CAPSET_VENUS) as u64,
+        )
+        .set_rutabaga_channels(rutabaga_channels_opt)
+        .set_use_egl(true)
+        .set_use_gles(true)
+        .set_use_glx(true)
+        .set_use_surfaceless(true)
+        .set_use_external_blob(true);
         // TODO: figure out if we need this:
         // this was part of libkrun modification and not upstream crossvm rutabaga
         //.set_use_drm(true);

--- a/staging/vhost-device-gpu/src/virt_gpu.rs
+++ b/staging/vhost-device-gpu/src/virt_gpu.rs
@@ -283,6 +283,9 @@ pub struct RutabagaVirtioGpu {
 }
 
 impl RutabagaVirtioGpu {
+    // TODO: this depends on Rutabaga builder, so this will need to be handled at runtime eventually
+    pub const MAX_NUMBER_OF_CAPSETS: u32 = 3;
+
     fn create_fence_handler(
         queue_ctl: VringRwLock,
         fence_state: Arc<Mutex<FenceState>>,

--- a/staging/vhost-device-gpu/src/virt_gpu.rs
+++ b/staging/vhost-device-gpu/src/virt_gpu.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::vhu_gpu::Error;
 use libc::c_void;
-use log::{debug, error};
+use log::{debug, error, trace};
 use rutabaga_gfx::{
     ResourceCreate3D, ResourceCreateBlob, Rutabaga, RutabagaBuilder, RutabagaChannel,
     RutabagaFence, RutabagaFenceHandler, RutabagaIovec, RutabagaResult, Transfer3D,
@@ -316,6 +316,7 @@ impl VirtioGpuResource {
 
 pub struct VirtioGpuScanout {
     resource_id: u32,
+    rect: Rectangle,
 }
 
 pub struct RutabagaVirtioGpu {
@@ -589,7 +590,7 @@ impl VirtioGpu for RutabagaVirtioGpu {
             .ok_or(ErrInvalidResourceId)?;
 
         resource.scanouts.enable(scanout_id);
-        *scanout = Some(VirtioGpuScanout { resource_id });
+        *scanout = Some(VirtioGpuScanout { resource_id, rect });
         Ok(OkNoData)
     }
 
@@ -683,8 +684,26 @@ impl VirtioGpu for RutabagaVirtioGpu {
         &mut self,
         ctx_id: u32,
         resource_id: u32,
-        transfer: Transfer3D,
+        mut transfer: Transfer3D,
     ) -> VirtioGpuResult {
+        trace!("transfer_write ctx_id {ctx_id}, resource_id {resource_id}, {transfer:?}");
+
+        let resource = self
+            .resources
+            .get_mut(&resource_id)
+            .ok_or(ErrInvalidResourceId)?;
+
+        // FIXME: this is a horrible hack, that makes transfer_read in flush_resource work properly
+        // without this workaround partial transfer_write (not the whole area of the screen) seems
+        // to produce mostly black / empty images
+        if let Some(scanout_id) = resource.scanouts.iter_enabled().next() {
+            let rect = &mut self.scanouts[scanout_id as usize].as_mut().unwrap().rect;
+            transfer.x = 0;
+            transfer.y = 0;
+            transfer.w = rect.width;
+            transfer.h = rect.height;
+        }
+
         self.rutabaga
             .transfer_write(ctx_id, resource_id, transfer)?;
         Ok(OkNoData)

--- a/staging/vhost-device-gpu/src/virt_gpu.rs
+++ b/staging/vhost-device-gpu/src/virt_gpu.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use crate::vhu_gpu::Error;
-use crate::virtio_gpu::VirtioScanoutBlobData;
 use libc::c_void;
 use log::{debug, error};
 use rutabaga_gfx::{
@@ -56,14 +55,6 @@ fn sglist_to_rutabaga_iovecs(
 }
 
 pub trait VirtioGpu {
-    fn update_scanout_resource(
-        &mut self,
-        gpu_backend: &mut GpuBackend,
-        gpu_scanout: VhostUserGpuScanout,
-        resource_id: u32,
-        scanout_data: Option<VirtioScanoutBlobData>,
-    ) -> VirtioGpuResult;
-
     /// Uses the hypervisor to unmap the blob resource.
     fn resource_unmap_blob(
         &mut self,
@@ -141,7 +132,6 @@ pub trait VirtioGpu {
         gpu_backend: &mut GpuBackend,
         gpu_scanout: VhostUserGpuScanout,
         resource_id: u32,
-        scanout_data: Option<VirtioScanoutBlobData>,
     ) -> VirtioGpuResult;
 
     /// Creates a 3D resource with the given properties and resource_id.
@@ -260,7 +250,6 @@ pub struct VirtioGpuResource {
     pub size: u64,
     pub shmem_offset: Option<u64>,
     pub rutabaga_external_mapping: bool,
-    pub scanout_data: Option<VirtioScanoutBlobData>,
 }
 
 impl VirtioGpuResource {
@@ -271,7 +260,6 @@ impl VirtioGpuResource {
             size,
             shmem_offset: None,
             rutabaga_external_mapping: false,
-            scanout_data: None,
         }
     }
 }
@@ -458,9 +446,36 @@ impl VirtioGpu for RutabagaVirtioGpu {
         gpu_backend: &mut GpuBackend,
         gpu_scanout: VhostUserGpuScanout,
         resource_id: u32,
-        scanout_data: Option<VirtioScanoutBlobData>,
     ) -> VirtioGpuResult {
-        self.update_scanout_resource(gpu_backend, gpu_scanout, resource_id, scanout_data)
+        gpu_backend.set_scanout(&gpu_scanout).map_err(|e| {
+            error!("Failed to set scanout from frontend: {}", e);
+            ErrUnspec
+        })?;
+
+        // Virtio spec: "The driver can use resource_id = 0 to disable a scanout."
+        if resource_id == 0 {
+            error!("NOT IMPLEMENTED: disable scanout");
+            return Ok(OkNoData);
+        }
+
+        let _resource = self
+            .resources
+            .get_mut(&resource_id)
+            .ok_or(ErrInvalidResourceId)?;
+
+        //todo:
+        //create a display surface
+
+        // `resource_id` has already been verified to be non-zero
+        let resource_id = match NonZeroU32::new(resource_id) {
+            Some(id) => id,
+            None => return Ok(OkNoData),
+        };
+        //todo:
+        //store resource_id in a struct that will be used later
+        debug!("resource id: {:?}", resource_id);
+
+        Ok(OkNoData)
     }
 
     fn resource_create_3d(
@@ -810,46 +825,6 @@ impl VirtioGpu for RutabagaVirtioGpu {
         }
 
         resource.shmem_offset = None;
-
-        Ok(OkNoData)
-    }
-
-    fn update_scanout_resource(
-        &mut self,
-        gpu_backend: &mut GpuBackend,
-        gpu_scanout: VhostUserGpuScanout,
-        resource_id: u32,
-        scanout_data: Option<VirtioScanoutBlobData>,
-    ) -> VirtioGpuResult {
-        gpu_backend.set_scanout(&gpu_scanout).map_err(|e| {
-            error!("Failed to set scanout from frontend: {}", e);
-            ErrUnspec
-        })?;
-
-        // Virtio spec: "The driver can use resource_id = 0 to disable a scanout."
-        if resource_id == 0 {
-            error!("NOT IMPLEMENTED: disable scanout");
-            return Ok(OkNoData);
-        }
-
-        let resource = self
-            .resources
-            .get_mut(&resource_id)
-            .ok_or(ErrInvalidResourceId)?;
-
-        resource.scanout_data = scanout_data;
-
-        //todo:
-        //create a display surface
-
-        // `resource_id` has already been verified to be non-zero
-        let resource_id = match NonZeroU32::new(resource_id) {
-            Some(id) => id,
-            None => return Ok(OkNoData),
-        };
-        //todo:
-        //store resource_id in a struct that will be used later
-        debug!("resource id: {:?}", resource_id);
 
         Ok(OkNoData)
     }

--- a/staging/vhost-device-gpu/src/virt_gpu.rs
+++ b/staging/vhost-device-gpu/src/virt_gpu.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::env;
+use std::io::IoSliceMut;
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -9,14 +10,15 @@ use libc::c_void;
 use log::{debug, error};
 use rutabaga_gfx::{
     ResourceCreate3D, ResourceCreateBlob, Rutabaga, RutabagaBuilder, RutabagaChannel,
-    RutabagaFence, RutabagaFenceHandler, RutabagaIovec, Transfer3D, RUTABAGA_CHANNEL_TYPE_WAYLAND,
-    RUTABAGA_MAP_ACCESS_MASK, RUTABAGA_MAP_ACCESS_READ, RUTABAGA_MAP_ACCESS_RW,
-    RUTABAGA_MAP_ACCESS_WRITE, RUTABAGA_MAP_CACHE_MASK, RUTABAGA_MEM_HANDLE_TYPE_OPAQUE_FD,
+    RutabagaFence, RutabagaFenceHandler, RutabagaIovec, RutabagaResult, Transfer3D,
+    RUTABAGA_CHANNEL_TYPE_WAYLAND, RUTABAGA_MAP_ACCESS_MASK, RUTABAGA_MAP_ACCESS_READ,
+    RUTABAGA_MAP_ACCESS_RW, RUTABAGA_MAP_ACCESS_WRITE, RUTABAGA_MAP_CACHE_MASK,
+    RUTABAGA_MEM_HANDLE_TYPE_OPAQUE_FD,
 };
 //use utils::eventfd::EventFd;
 use vhost::vhost_user::gpu_message::{
     VhostUserGpuCursorPos, VhostUserGpuCursorUpdate, VhostUserGpuEdidRequest, VhostUserGpuScanout,
-    VirtioGpuRespDisplayInfo,
+    VhostUserGpuUpdate, VirtioGpuRespDisplayInfo,
 };
 use vhost_user_backend::{VringRwLock, VringT};
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, VolatileSlice};
@@ -165,7 +167,12 @@ pub trait VirtioGpu {
     fn unref_resource(&mut self, resource_id: u32) -> VirtioGpuResult;
 
     /// If the resource is the scanout resource, flush it to the display.
-    fn flush_resource(&mut self, resource_id: u32) -> VirtioGpuResult;
+    fn flush_resource(
+        &mut self,
+        resource_id: u32,
+        gpu_backend: &mut GpuBackend,
+        rect: Rectangle,
+    ) -> VirtioGpuResult;
 
     /// Copies data to host resource from the attached iovecs. Can also be used to flush caches.
     fn transfer_write(
@@ -276,6 +283,12 @@ impl AssociatedScanouts {
     fn disable(&mut self, scanout_id: u32) {
         self.0 ^= 1 << scanout_id;
     }
+
+    fn iter_enabled(self) -> impl Iterator<Item = u32> {
+        (0..VIRTIO_GPU_MAX_SCANOUTS)
+            .filter(move |i| ((self.0 >> i) & 1) == 1)
+            .map(|n| n as u32)
+    }
 }
 
 #[derive(Default)]
@@ -311,6 +324,8 @@ pub struct RutabagaVirtioGpu {
     pub(crate) fence_state: Arc<Mutex<FenceState>>,
     pub(crate) scanouts: [Option<VirtioGpuScanout>; VIRTIO_GPU_MAX_SCANOUTS],
 }
+
+const READ_RESOURCE_BYTES_PER_PIXEL: usize = 4;
 
 impl RutabagaVirtioGpu {
     // TODO: this depends on Rutabaga builder, so this will need to be handled at runtime eventually
@@ -453,6 +468,35 @@ impl RutabagaVirtioGpu {
             Err(_) => OkNoData,
         }
     }
+
+    fn read_2d_resource(
+        &mut self,
+        resource_id: u32,
+        rect: &Rectangle,
+        output: &mut [u8],
+    ) -> RutabagaResult<()> {
+        let result_len = rect.width as usize * rect.height as usize * READ_RESOURCE_BYTES_PER_PIXEL;
+        assert!(output.len() >= result_len);
+
+        let transfer = Transfer3D {
+            x: rect.x,
+            y: rect.y,
+            z: 0,
+            w: rect.width,
+            h: rect.height,
+            d: 1,
+            level: 0,
+            stride: rect.width * READ_RESOURCE_BYTES_PER_PIXEL as u32,
+            layer_stride: 0,
+            offset: 0,
+        };
+
+        // ctx_id 0 seems to be special, crosvm uses it for this purpose too
+        self.rutabaga
+            .transfer_read(0, resource_id, transfer, Some(IoSliceMut::new(output)))?;
+
+        Ok(())
+    }
 }
 
 impl VirtioGpu for RutabagaVirtioGpu {
@@ -583,9 +627,46 @@ impl VirtioGpu for RutabagaVirtioGpu {
         Ok(OkNoData)
     }
 
-    fn flush_resource(&mut self, resource_id: u32) -> VirtioGpuResult {
+    /// If the resource is the scanout resource, flush it to the display.
+    fn flush_resource(
+        &mut self,
+        resource_id: u32,
+        gpu_backend: &mut GpuBackend,
+        rect: Rectangle,
+    ) -> VirtioGpuResult {
         if resource_id == 0 {
             return Ok(OkNoData);
+        }
+
+        let resource = self
+            .resources
+            .get(&resource_id)
+            .ok_or(ErrInvalidResourceId)?;
+
+        for scanout_id in resource.scanouts.iter_enabled() {
+            let mut image_data =
+                vec![0; rect.width as usize * rect.height as usize * READ_RESOURCE_BYTES_PER_PIXEL];
+
+            if let Err(e) = self.read_2d_resource(resource_id, &rect, &mut image_data) {
+                log::error!("Failed to read resource {resource_id} for scanout {scanout_id}: {e}");
+                continue;
+            }
+
+            gpu_backend
+                .update_scanout(
+                    &VhostUserGpuUpdate {
+                        scanout_id,
+                        x: rect.x,
+                        y: rect.y,
+                        width: rect.width,
+                        height: rect.height,
+                    },
+                    &image_data,
+                )
+                .map_err(|e| {
+                    error!("Failed to update_scanout: {e:?}");
+                    ErrUnspec
+                })?
         }
 
         #[cfg(windows)]

--- a/staging/vhost-device-gpu/src/virtio_gpu.rs
+++ b/staging/vhost-device-gpu/src/virtio_gpu.rs
@@ -102,15 +102,6 @@ pub const VIRTIO_GPU_CMD_RESOURCE_UNMAP_BLOB: u32 = 0x209;
 pub const VIRTIO_GPU_CMD_UPDATE_CURSOR: u32 = 0x300;
 pub const VIRTIO_GPU_CMD_MOVE_CURSOR: u32 = 0x301;
 
-///This structure contains the scanout blob data
-#[derive(Copy, Clone, Debug)]
-pub struct VirtioScanoutBlobData {
-    pub width: u32,
-    pub height: u32,
-    pub strides: [u32; 4],
-    pub offsets: [u32; 4],
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct InvalidCommandType(u32);
 


### PR DESCRIPTION
This PR enables the guest to use CmdSubmit3d, by specifying a non-zero number of capsets. 
This PR also implements basic support display output in QEMU using `gpu_backend.set_scanout` and  `gpu_backend.update_scanout`.