### PR TITLE
Update vhost crate + fix test compilation

### DIFF
--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -1079,7 +1079,6 @@ dependencies = [
  "vhost-user-backend 0.15.0",
  "virtio-bindings",
  "virtio-queue 0.12.0",
- "vm-memory 0.13.1",
  "vm-memory 0.14.0",
  "vmm-sys-util 0.12.1",
  "zerocopy 0.6.6",

--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.11.0"
-source = "git+https://github.com/mtjhrc/vhost.git?branch=gpuwork-rebased#a9cbbc2438e289cd64e7be40b65047a3db1b1880"
+source = "git+https://github.com/mtjhrc/vhost.git?branch=gpu-socket-final#e1b1ab4fcdb07ef23d3c298281598c4205d83abb"
 dependencies = [
  "bitflags 2.4.1",
  "libc",
@@ -1076,7 +1076,7 @@ dependencies = [
  "rutabaga_gfx",
  "thiserror",
  "vhost 0.11.0",
- "vhost-user-backend 0.14.0",
+ "vhost-user-backend 0.15.0",
  "virtio-bindings",
  "virtio-queue 0.12.0",
  "vm-memory 0.13.1",
@@ -1148,8 +1148,8 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.14.0"
-source = "git+https://github.com/mtjhrc/vhost.git?branch=gpuwork-rebased#a9cbbc2438e289cd64e7be40b65047a3db1b1880"
+version = "0.15.0"
+source = "git+https://github.com/mtjhrc/vhost.git?branch=gpu-socket-final#e1b1ab4fcdb07ef23d3c298281598c4205d83abb"
 dependencies = [
  "libc",
  "log",

--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -32,4 +32,4 @@ zerocopy-derive = "0.6.3"
 [dev-dependencies]
 assert_matches = "1.5"
 virtio-queue = { version = "0.12", features = ["test-utils"] }
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }

--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -20,8 +20,8 @@ libc = "0.2"
 log = "0.4"
 rutabaga_gfx = { path = "rutabaga_gfx", features = ["virgl_renderer"] }
 thiserror = "1.0"
-vhost = { git = "https://github.com/mtjhrc/vhost.git", package = "vhost", branch = "gpuwork-rebased", features = ["vhost-user-backend"] }
-vhost-user-backend = { git = "https://github.com/mtjhrc/vhost.git", package = "vhost-user-backend", branch = "gpuwork-rebased",  features = ["gpu-set-socket"] }
+vhost = { git = "https://github.com/mtjhrc/vhost.git", package = "vhost", branch = "gpu-socket-final", features = ["vhost-user-backend"] }
+vhost-user-backend = { git = "https://github.com/mtjhrc/vhost.git", package = "vhost-user-backend", branch = "gpu-socket-final",  features = ["gpu-socket"] }
 virtio-bindings = "0.2.2"
 virtio-queue = "0.12.0"
 vm-memory = "0.14.0"


### PR DESCRIPTION
Use the vhost crate, from the branch that is going to be merged upstream.


This PR also fixes tests not compiling due to different vm-memory version.