### PR TITLE
Implement calling Rutabaga::event_poll(), to fix virglrenderer hang up

### DIFF
--- a/staging/vhost-device-gpu/src/main.rs
+++ b/staging/vhost-device-gpu/src/main.rs
@@ -4,11 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
 use log::{error, info};
-use std::{
-    path::PathBuf,
-    process::exit,
-    sync::{Arc, RwLock},
-};
+use std::{path::PathBuf, process::exit};
 
 use clap::Parser;
 use thiserror::Error as ThisError;
@@ -51,10 +47,7 @@ impl TryFrom<GpuArgs> for GpuConfig {
 
 fn start_backend(config: GpuConfig) -> Result<()> {
     info!("Starting backend");
-    let backend = Arc::new(RwLock::new(
-        VhostUserGpuBackend::new(config.clone()).map_err(Error::CouldNotCreateBackend)?,
-    ));
-
+    let backend = VhostUserGpuBackend::new(config.clone()).map_err(Error::CouldNotCreateBackend)?;
     let socket = config.get_socket_path();
 
     let mut daemon = VhostUserDaemon::new(

--- a/staging/vhost-device-gpu/src/main.rs
+++ b/staging/vhost-device-gpu/src/main.rs
@@ -52,10 +52,12 @@ fn start_backend(config: GpuConfig) -> Result<()> {
 
     let mut daemon = VhostUserDaemon::new(
         String::from("vhost-device-gpu-backend"),
-        backend,
+        backend.clone(),
         GuestMemoryAtomic::new(GuestMemoryMmap::new()),
     )
     .map_err(Error::CouldNotCreateDaemon)?;
+
+    backend.set_epoll_handler(&daemon.get_epoll_handlers());
 
     daemon.serve(socket).map_err(Error::ServeFailed)?;
     Ok(())

--- a/staging/vhost-device-gpu/src/protocol.rs
+++ b/staging/vhost-device-gpu/src/protocol.rs
@@ -69,6 +69,7 @@ pub const NUM_QUEUES: usize = 2;
 
 pub const CONTROL_QUEUE: u16 = 0;
 pub const CURSOR_QUEUE: u16 = 1;
+pub const POLL_EVENT: u16 = NUM_QUEUES as u16 + 1;
 
 pub const VIRTIO_GPU_MAX_SCANOUTS: usize = 16;
 

--- a/staging/vhost-device-gpu/src/virtio_gpu.rs
+++ b/staging/vhost-device-gpu/src/virtio_gpu.rs
@@ -13,7 +13,6 @@ use libc::c_void;
 use rutabaga_gfx::{
     ResourceCreate3D, ResourceCreateBlob, Rutabaga, RutabagaBuilder, RutabagaChannel,
     RutabagaFence, RutabagaFenceHandler, RutabagaIovec, RutabagaResult, Transfer3D,
-    RUTABAGA_CAPSET_DRM, RUTABAGA_CAPSET_VENUS, RUTABAGA_CAPSET_VIRGL, RUTABAGA_CAPSET_VIRGL2,
     RUTABAGA_CHANNEL_TYPE_WAYLAND, RUTABAGA_MAP_ACCESS_MASK, RUTABAGA_MAP_ACCESS_READ,
     RUTABAGA_MAP_ACCESS_RW, RUTABAGA_MAP_ACCESS_WRITE, RUTABAGA_MAP_CACHE_MASK,
     RUTABAGA_MEM_HANDLE_TYPE_OPAQUE_FD,
@@ -401,19 +400,13 @@ impl RutabagaVirtioGpu {
             channel_type: RUTABAGA_CHANNEL_TYPE_WAYLAND,
         }];
         let rutabaga_channels_opt = Some(rutabaga_channels);
-        let builder = RutabagaBuilder::new(
-            rutabaga_gfx::RutabagaComponentType::VirglRenderer,
-            (RUTABAGA_CAPSET_VIRGL
-                | RUTABAGA_CAPSET_VIRGL2
-                | RUTABAGA_CAPSET_DRM
-                | RUTABAGA_CAPSET_VENUS) as u64,
-        )
-        .set_rutabaga_channels(rutabaga_channels_opt)
-        .set_use_egl(true)
-        .set_use_gles(true)
-        .set_use_glx(true)
-        .set_use_surfaceless(true)
-        .set_use_external_blob(true);
+        let builder = RutabagaBuilder::new(rutabaga_gfx::RutabagaComponentType::VirglRenderer, 0)
+            .set_rutabaga_channels(rutabaga_channels_opt)
+            .set_use_egl(true)
+            .set_use_gles(true)
+            .set_use_glx(true)
+            .set_use_surfaceless(true)
+            .set_use_external_blob(true);
 
         let fence_state = Arc::new(Mutex::new(Default::default()));
         let fence = Self::create_fence_handler(queue_ctl.clone(), fence_state.clone());


### PR DESCRIPTION
This PR fixes the `timeout (5s) waiting for renderer poll() to finish` virgl hang up properly this time.

This is acomplished by calling `Rutabaga::event_poll()` when we are notified using the eventfd
obtained from `Rutabaga::poll_descriptor()`.

This refactors `VhostUserGPUBackend` to implement the `VhostUserBackend` trait instead of `VhostUserBackendMut` we were implementing before.

Registering a custom epoll handler required the refactoring - we cannot use the `VhostUserBackendMut` and put every method call behind a `Mutex` or `RwLock` like we were implicitly doing before. This is because we need to call `VringEpollHandler::register_listener` from within `handle_event()`, but `VringEpollHandler::register_listener` calls `VhostUserBackend::num_queues`, which would deadlock using the default blanket implemantion `impl<T: VhostUserBackendMut> VhostUserBackend for RwLock<T>` inside vhost-user-backend crate we were using before.

This refactor also has an advantage that we don't need to lock a mutex for simple calls like `num_queues()` method.