### PR TITLE
Add support for ResourceAssignUuid command

### DIFF
--- a/staging/vhost-device-gpu/src/device.rs
+++ b/staging/vhost-device-gpu/src/device.rs
@@ -8,14 +8,14 @@ use crate::{
     protocol::{
         virtio_gpu_box, virtio_gpu_ctrl_hdr, virtio_gpu_ctx_create, virtio_gpu_ctx_resource,
         virtio_gpu_cursor_pos, virtio_gpu_get_capset, virtio_gpu_get_capset_info,
-        virtio_gpu_get_edid, virtio_gpu_rect, virtio_gpu_resource_attach_backing,
-        virtio_gpu_resource_create_2d, virtio_gpu_resource_create_3d,
-        virtio_gpu_resource_detach_backing, virtio_gpu_resource_flush, virtio_gpu_resource_unref,
-        virtio_gpu_set_scanout, virtio_gpu_transfer_host_3d, virtio_gpu_transfer_to_host_2d,
-        virtio_gpu_update_cursor, GpuCommand, GpuCommandDecodeError, GpuResponse::ErrUnspec,
-        GpuResponseEncodeError, VirtioGpuConfig, VirtioGpuResult, CONTROL_QUEUE, CURSOR_QUEUE,
-        NUM_QUEUES, POLL_EVENT, QUEUE_SIZE, VIRTIO_GPU_FLAG_FENCE, VIRTIO_GPU_FLAG_INFO_RING_IDX,
-        VIRTIO_GPU_MAX_SCANOUTS,
+        virtio_gpu_get_edid, virtio_gpu_rect, virtio_gpu_resource_assign_uuid,
+        virtio_gpu_resource_attach_backing, virtio_gpu_resource_create_2d,
+        virtio_gpu_resource_create_3d, virtio_gpu_resource_detach_backing,
+        virtio_gpu_resource_flush, virtio_gpu_resource_unref, virtio_gpu_set_scanout,
+        virtio_gpu_transfer_host_3d, virtio_gpu_transfer_to_host_2d, virtio_gpu_update_cursor,
+        GpuCommand, GpuCommandDecodeError, GpuResponse::ErrUnspec, GpuResponseEncodeError,
+        VirtioGpuConfig, VirtioGpuResult, CONTROL_QUEUE, CURSOR_QUEUE, NUM_QUEUES, POLL_EVENT,
+        QUEUE_SIZE, VIRTIO_GPU_FLAG_FENCE, VIRTIO_GPU_FLAG_INFO_RING_IDX, VIRTIO_GPU_MAX_SCANOUTS,
     },
     virtio_gpu::{RutabagaVirtioGpu, VirtioGpu, VirtioGpuRing},
     GpuConfig, GpuMode,
@@ -46,7 +46,7 @@ use virtio_bindings::{
     },
     virtio_gpu::{
         VIRTIO_GPU_F_CONTEXT_INIT, VIRTIO_GPU_F_EDID, VIRTIO_GPU_F_RESOURCE_BLOB,
-        VIRTIO_GPU_F_VIRGL,
+        VIRTIO_GPU_F_RESOURCE_UUID, VIRTIO_GPU_F_VIRGL,
     },
 };
 use virtio_queue::{QueueOwnedT, Reader, Writer};
@@ -246,9 +246,9 @@ impl VhostUserGpuBackendInner {
                 let cursor = VhostUserGpuCursorPos { scanout_id, x, y };
                 virtio_gpu.move_cursor(resource_id, cursor)
             }
-            GpuCommand::ResourceAssignUuid(_info) => {
-                panic!("virtio_gpu: GpuCommand::ResourceAssignUuid unimplemented");
-            }
+            GpuCommand::ResourceAssignUuid(virtio_gpu_resource_assign_uuid {
+                resource_id, ..
+            }) => virtio_gpu.resource_assign_uuid(resource_id),
             GpuCommand::GetCapsetInfo(virtio_gpu_get_capset_info { capset_index, .. }) => {
                 virtio_gpu.get_capset_info(capset_index)
             }
@@ -633,6 +633,7 @@ impl VhostUserBackend for VhostUserGpuBackend {
             | 1 << VIRTIO_RING_F_EVENT_IDX
             | 1 << VIRTIO_GPU_F_VIRGL
             | 1 << VIRTIO_GPU_F_EDID
+            | 1 << VIRTIO_GPU_F_RESOURCE_UUID
             | 1 << VIRTIO_GPU_F_RESOURCE_BLOB
             | 1 << VIRTIO_GPU_F_CONTEXT_INIT
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()

--- a/staging/vhost-device-gpu/src/virtio_gpu.rs
+++ b/staging/vhost-device-gpu/src/virtio_gpu.rs
@@ -753,9 +753,11 @@ impl VirtioGpu for RutabagaVirtioGpu {
     }
 
     fn resource_assign_uuid(&self, resource_id: u32) -> VirtioGpuResult {
-        if !self.resources.contains_key(&resource_id) {
-            return Err(ErrInvalidResourceId);
-        }
+        debug_assert!(
+            self.resources.contains_key(&resource_id),
+            "Resource ID {} doesn't exists in the resources map.",
+            resource_id
+        );
 
         // TODO(stevensd): use real uuids once the virtio wayland protocol is updated to
         // handle more than 32 bits. For now, the virtwl driver knows that the uuid is


### PR DESCRIPTION
add support for ResourceAssignUuuid, this includes the feature negotiation `VIRTIO_GPU_F_RESOURCE_UUID`, which is responsible for assigning resources UUIDs for export to other virtio devices.