### PR TITLE
Add CLI arguments to make the device more configurable.

### DIFF
--- a/.buildkite/staging-tests.json
+++ b/.buildkite/staging-tests.json
@@ -11,7 +11,7 @@
     },
     {
       "test_name": "staging: build-musl",
-      "command": "cd staging && RUSTFLAGS=\"-D warnings\" cargo build --release --target {target_platform}-unknown-linux-musl",
+      "command": "cd staging && RUSTFLAGS=\"-D warnings\" cargo build --release --workspace --exclude vhost-device-gpu --target {target_platform}-unknown-linux-musl",
       "soft_fail": "true",
       "platform": [
         "x86_64",
@@ -33,7 +33,7 @@
     },
     {
       "test_name": "staging: unittests-musl",
-      "command": "cd staging && cargo test --all-features --workspace --target {target_platform}-unknown-linux-musl",
+      "command": "cd staging && cargo test --all-features --workspace --exclude vhost-device-gpu --target {target_platform}-unknown-linux-musl",
       "soft_fail": "true",
       "platform": [
         "x86_64",

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Add the list of code owners here (using their GitHub username)
 * @stsquad @vireshk @stefano-garzarella @epilys
+/vhost-device-scmi/ @mz-pdm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
  "yansi-term",
 ]
 
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arc-swap"
@@ -193,16 +193,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "byte_conv"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649972315d4931137a26fc2bf3ca95ee257ad796a5b57bdeb04205c91a4b5780"
-
-[[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -212,9 +206,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
 dependencies = [
  "shlex",
 ]
@@ -263,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -273,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -297,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -309,15 +303,15 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -380,15 +374,15 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -396,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -436,12 +430,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -469,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "figment"
@@ -606,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -639,11 +633,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -676,15 +670,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -697,6 +682,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -721,9 +715,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgpiod"
@@ -825,15 +819,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -901,19 +886,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
 ]
 
 [[package]]
@@ -1093,9 +1065,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1138,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1227,15 +1199,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
- "errno 0.3.9",
+ "errno 0.3.10",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1264,24 +1236,24 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1362,22 +1334,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "socketcan"
-version = "3.3.1"
+name = "socket2"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d763e285beeb053e7fcd785d747ab1f8f669966991f33586e0f1d5d2340bce7e"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
- "bitflags 1.3.2",
- "byte_conv",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socketcan"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7654092b2859221c29ac4b43dc502a8e156a7f2533e8617aaaa056b664d1230e"
+dependencies = [
+ "bitflags 2.6.0",
  "embedded-can",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "libc",
  "log",
  "nb",
  "neli",
- "nix 0.26.4",
- "thiserror 1.0.69",
+ "nix 0.29.0",
+ "socket2",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -1490,11 +1472,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -1510,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1590,6 +1572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,7 +1652,7 @@ dependencies = [
  "log",
  "queues",
  "socketcan",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1685,7 +1673,7 @@ dependencies = [
  "epoll",
  "log",
  "queues",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1704,7 +1692,7 @@ dependencies = [
  "libc",
  "libgpiod",
  "log",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1722,7 +1710,7 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1745,7 +1733,7 @@ dependencies = [
  "nix 0.29.0",
  "rand",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1766,7 +1754,7 @@ dependencies = [
  "log",
  "rand",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1782,9 +1770,9 @@ dependencies = [
  "assert_matches",
  "clap",
  "env_logger",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1804,7 +1792,7 @@ dependencies = [
  "log",
  "num_enum",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1826,7 +1814,7 @@ dependencies = [
  "rstest",
  "rusty-fork",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1845,7 +1833,7 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1863,7 +1851,7 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1886,7 +1874,7 @@ dependencies = [
  "log",
  "serde",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -2108,9 +2096,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1475abae4f8ad4998590fe3acfe20104f0a5d48fc420c817cd2c09c3f56151f0"
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1236,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1800,6 +1824,7 @@ dependencies = [
  "pipewire",
  "rand",
  "rstest",
+ "rusty-fork",
  "tempfile",
  "thiserror 2.0.3",
  "vhost",
@@ -1948,6 +1973,15 @@ checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
 dependencies = [
  "libc",
  "nix 0.29.0",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ checksum = "649972315d4931137a26fc2bf3ca95ee257ad796a5b57bdeb04205c91a4b5780"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "byteorder"
@@ -212,9 +212,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "shlex",
 ]
@@ -606,9 +606,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -624,12 +624,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -654,9 +648,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -703,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "lazy_static"
@@ -721,9 +715,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libgpiod"
@@ -750,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets",
@@ -849,11 +843,10 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "log",
  "wasi",
@@ -1073,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1222,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno 0.3.9",
@@ -1556,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,6 +1798,7 @@ dependencies = [
  "env_logger",
  "log",
  "pipewire",
+ "rand",
  "rstest",
  "tempfile",
  "thiserror 2.0.3",

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ More information may be found in its [README file](./staging/README.md).
 Here is the list of device backends in **staging**:
 
 - [Video](https://github.com/rust-vmm/vhost-device/blob/main/staging/vhost-device-video/README.md)
+- [GPU](https://github.com/rust-vmm/vhost-device/blob/main/staging/vhost-device-gpu/README.md)
 
 <!--
 Template:

--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -57,14 +57,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arc-swap"
@@ -116,9 +116,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -223,14 +223,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fnv"
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -399,9 +399,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -556,15 +556,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -596,9 +596,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -720,15 +720,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "slab"
@@ -784,9 +784,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -803,14 +803,14 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -823,11 +823,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -942,7 +942,7 @@ dependencies = [
  "rusty-fork",
  "rutabaga_gfx",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -966,7 +966,7 @@ dependencies = [
  "num_enum",
  "rstest",
  "tempfile",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "v4l2r",
  "vhost",
  "vhost-user-backend",
@@ -1072,15 +1072,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -1154,9 +1145,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
 dependencies = [
  "memchr",
 ]

--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -218,12 +218,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -359,9 +359,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -383,9 +383,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -399,9 +399,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "linux-raw-sys"
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -720,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -784,9 +784,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "utf8parse"

--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -934,6 +934,7 @@ name = "vhost-device-gpu"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "bitflags 2.6.0",
  "clap",
  "env_logger",
  "libc",

--- a/staging/coverage_config_x86_64.json
+++ b/staging/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 79.80,
+  "coverage_score": 82.43,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -34,6 +34,7 @@ virtio-bindings = "0.2.2"
 virtio-queue = "0.14.0"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.12.1"
+bitflags = "2.6.0"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -10,9 +10,14 @@ categories = ["multimedia::video", "virtualization"]
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2021"
 publish = false
+# "Features enabled on platform-specific dependencies for target architectures not currently being built are ignored."
+# See <https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2>
+resolver = "2"
 
 [features]
+default = ["gfxstream"]
 xen = ["vm-memory/xen", "vhost/xen", "vhost-user-backend/xen"]
+gfxstream = ["rutabaga_gfx/gfxstream"]
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }
@@ -21,7 +26,7 @@ libc = "0.2"
 log = "0.4"
 
 [target.'cfg(not(target_env = "musl"))'.dependencies]
-rutabaga_gfx = { version = "0.1.4", features = ["gfxstream", "virgl_renderer"] }
+rutabaga_gfx = { version = "0.1.4", features = ["virgl_renderer"] }
 thiserror = "2.0.3"
 vhost = { version = "0.13.0", features = ["vhost-user-backend"] }
 vhost-user-backend = "0.17"

--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -20,14 +20,14 @@ xen = ["vm-memory/xen", "vhost/xen", "vhost-user-backend/xen"]
 gfxstream = ["rutabaga_gfx/gfxstream"]
 
 [dependencies]
-clap = { version = "4.4", features = ["derive"] }
-env_logger = "0.11.5"
+clap = { version = "4.5", features = ["derive"] }
+env_logger = "0.11.6"
 libc = "0.2"
 log = "0.4"
 
 [target.'cfg(not(target_env = "musl"))'.dependencies]
 rutabaga_gfx = { version = "0.1.4", features = ["virgl_renderer"] }
-thiserror = "2.0.3"
+thiserror = "2.0.9"
 vhost = { version = "0.13.0", features = ["vhost-user-backend"] }
 vhost-user-backend = "0.17"
 virtio-bindings = "0.2.2"

--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -32,8 +32,8 @@ vmm-sys-util = "0.12.1"
 
 [dev-dependencies]
 assert_matches = "1.5"
+mockall = "0.13.0"
+rusty-fork = "0.3.0"
 tempfile = "3.13"
 virtio-queue = { version = "0.14", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
-mockall = "0.13.0"
-rusty-fork = "0.3.0"

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -1,36 +1,34 @@
 # vhost-device-gpu - GPU emulation backend daemon
 
 ## Synopsis
+
 ```shell
-vhost-device-gpu --socket-path <SOCKET>
+vhost-device-gpu --socket-path <SOCKET> --gpu-mode <GPU_MODE>
 ```
 
 ## Description
+
 A virtio-gpu device using the vhost-user protocol.
 
 ## Options
 
 ```text
-       -s, --socket-path <SOCKET>
-              vhost-user Unix domain socket path
-
-       -h, --help
-              Print help
-
-       -V, --version
-              Print version
+  -s, --socket-path <SOCKET>  vhost-user Unix domain socket
+  -g, --gpu-mode <GPU_MODE>   [possible values: virgl-renderer, gfxstream]
+  -h, --help                  Print help
+  -V, --version               Print version
 ```
 
 ## Limitations
 
 We are currently only supporting sharing the display output to QEMU through a
 socket using the transfer_read operation triggered by
-VIRTIO_GPU_CMD_TRANSFER_FROM_HOST_3D to transfer data from and to virtio-gpu 3d
+`VIRTIO_GPU_CMD_TRANSFER_FROM_HOST_3D` to transfer data from and to virtio-gpu 3D
 resources. It'll be nice to have support for directly sharing display output
 resource using dmabuf.
 
-This device does not yet support the VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB,
-VIRTIO_GPU_CMD_SET_SCANOUT_BLOB and VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID features.
+This device does not yet support the `VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB`,
+`VIRTIO_GPU_CMD_SET_SCANOUT_BLOB` and `VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID` features.
 
 Currently this crate requires some necessary bits in order to move the crate out of staging:
 
@@ -40,18 +38,21 @@ Currently this crate requires some necessary bits in order to move the crate out
 
 ## Features
 
-The device leverages the [rutabaga_gfx](https://crates.io/crates/rutabaga_gfx) crate
-to provide virglrenderer and gfxstream rendering. With Virglrenderer, Rutabaga
-translates OpenGL API and Vulkan calls to an intermediate representation and allows
-for OpenGL acceleration on the host. With the gfxstream rendering mode, GLES and
-Vulkan calls are forwarded to the host with minimal modification.
+The device leverages the [rutabaga_gfx](https://crates.io/crates/rutabaga_gfx)
+crate to provide rendering with virglrenderer and gfxstream.
+
+With Virglrenderer, Rutabaga translates OpenGL API and Vulkan calls to an
+intermediate representation and allows for OpenGL acceleration on the host.
+
+With the gfxstream rendering mode, GLES and Vulkan calls are forwarded to the
+host with minimal modification.
 
 ## Examples
 
 First start the daemon on the host machine using either of the 2 gpu modes:
 
-1) virgl-renderer
-2) gfxstream
+1) `virgl-renderer`
+2) `gfxstream`
 
 ```shell
 host# vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode virgl-renderer

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -19,6 +19,9 @@ A virtio-gpu device using the vhost-user protocol.
   -V, --version               Print version
 ```
 
+_NOTE_: Option `-g, --gpu-mode` can only accept the `gfxstream` value if the
+crate has been built with the `gfxstream` feature, which is the default.
+
 ## Limitations
 
 We are currently only supporting sharing the display output to QEMU through a
@@ -41,6 +44,12 @@ Currently this crate requires some necessary bits in order to move the crate out
 The device leverages the [rutabaga_gfx](https://crates.io/crates/rutabaga_gfx)
 crate to provide rendering with virglrenderer and gfxstream.
 
+gfxstream support is compiled by default, it can be disabled by not building with the `gfxstream` feature flag, for example:
+
+```session
+$ cargo build --no-default-features
+```
+
 With Virglrenderer, Rutabaga translates OpenGL API and Vulkan calls to an
 intermediate representation and allows for OpenGL acceleration on the host.
 
@@ -52,7 +61,7 @@ host with minimal modification.
 First start the daemon on the host machine using either of the 2 gpu modes:
 
 1) `virgl-renderer`
-2) `gfxstream`
+2) `gfxstream` (if the crate has been compiled with the feature `gfxstream`)
 
 ```shell
 host# vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode virgl-renderer

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -34,8 +34,6 @@ VIRTIO_GPU_CMD_SET_SCANOUT_BLOB and VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID features
 
 Currently this crate requires some necessary bits in order to move the crate out of staging:
 
-- Achieving a minimum of ~87% code coverage in the main vhost-device repository,
-  which requires some additional unit tests to increase code coverage.
 - Addition of CLI arguments to specify the exact number of capsets and use
   a default capset configuration when no capset is specified rather than using
   hard-coded capset value.

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -14,7 +14,7 @@ A virtio-gpu device using the vhost-user protocol.
 
 ```text
   -s, --socket-path <SOCKET>  vhost-user Unix domain socket
-  -g, --gpu-mode <GPU_MODE>   [possible values: virgl-renderer, gfxstream]
+  -g, --gpu-mode <GPU_MODE>   [possible values: virglrenderer, gfxstream]
   -h, --help                  Print help
   -V, --version               Print version
 ```
@@ -60,11 +60,11 @@ host with minimal modification.
 
 First start the daemon on the host machine using either of the 2 gpu modes:
 
-1) `virgl-renderer`
+1) `virglrenderer`
 2) `gfxstream` (if the crate has been compiled with the feature `gfxstream`)
 
 ```shell
-host# vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode virgl-renderer
+host# vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode virglrenderer
 ```
 
 With QEMU, there are two device front-ends you can use with this device.

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -80,14 +80,11 @@ resources. It'll be nice to have support for directly sharing display output
 resource using dmabuf.
 
 This device does not yet support the `VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB`,
-`VIRTIO_GPU_CMD_SET_SCANOUT_BLOB` and `VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID` features.
-
-Currently this crate requires some necessary bits in order to move the crate out of staging:
-
-- Addition of CLI arguments to specify the exact number of capsets and use
-  a default capset configuration when no capset is specified rather than using
-  hard-coded capset value.
-
+`VIRTIO_GPU_CMD_SET_SCANOUT_BLOB` and `VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID` features. 
+This requires https://github.com/rust-vmm/vhost/pull/251, which in turn requires QEMU API stabilization.
+Because blob resources are not yet supported, some capsets are limited:
+- Venus (Vulkan implementation in virglrenderer project) support is not available at all.
+- gfxstream-vulkan and gfxstream-gles support are exposed, but can practically only be used for display output, there is no hardware acceleration yet.
 ## Features
 
 The device leverages the [rutabaga_gfx](https://crates.io/crates/rutabaga_gfx)

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -24,6 +24,11 @@ crate has been built with the `gfxstream` feature, which is the default.
 
 ## Limitations
 
+This device links native libaries (because of the usage of Rutabaga) compiled
+with GNU libc, so the CI is setup to not build this device for musl targets. 
+It might be possible to build those libraries using musl and then build the gpu
+device, but this is not tested.
+
 We are currently only supporting sharing the display output to QEMU through a
 socket using the transfer_read operation triggered by
 `VIRTIO_GPU_CMD_TRANSFER_FROM_HOST_3D` to transfer data from and to virtio-gpu 3D

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -13,10 +13,54 @@ A virtio-gpu device using the vhost-user protocol.
 ## Options
 
 ```text
-  -s, --socket-path <SOCKET>  vhost-user Unix domain socket
-  -g, --gpu-mode <GPU_MODE>   [possible values: virglrenderer, gfxstream]
-  -h, --help                  Print help
-  -V, --version               Print version
+  -s, --socket-path <SOCKET>
+          vhost-user Unix domain socket
+
+  -g, --gpu-mode <GPU_MODE>
+          The mode specifies which backend implementation to use
+          
+          [possible values: virglrenderer, gfxstream]
+
+  -c, --capset <CAPSET>
+          Comma separated list of enabled capsets
+
+          Possible values:
+          - virgl:            [virglrenderer] OpenGL implementation, superseded by Virgl2
+          - virgl2:           [virglrenderer] OpenGL implementation
+          - gfxstream-vulkan: [gfxstream] Vulkan implementation (partial support only)
+             NOTE: Can only be used for 2D display output for now, there is no hardware acceleration yet
+          - gfxstream-gles:   [gfxstream] OpenGL ES implementation (partial support only)
+             NOTE: Can only be used for 2D display output for now, there is no hardware acceleration yet
+
+      --use-egl <USE_EGL>
+          Enable backend to use EGL
+          
+          [default: true]
+          [possible values: true, false]
+
+      --use-glx <USE_GLX>
+          Enable backend to use GLX
+          
+          [default: false]
+          [possible values: true, false]
+
+      --use-gles <USE_GLES>
+          Enable backend to use GLES
+          
+          [default: true]
+          [possible values: true, false]
+
+      --use-surfaceless <USE_SURFACELESS>
+          Enable surfaceless backend option
+          
+          [default: true]
+          [possible values: true, false]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```
 
 _NOTE_: Option `-g, --gpu-mode` can only accept the `gfxstream` value if the

--- a/staging/vhost-device-gpu/src/device.rs
+++ b/staging/vhost-device-gpu/src/device.rs
@@ -728,8 +728,9 @@ mod tests {
     use crate::{
         protocol::{
             virtio_gpu_ctx_create, virtio_gpu_ctx_destroy, virtio_gpu_ctx_resource,
-            virtio_gpu_mem_entry, virtio_gpu_rect, virtio_gpu_resource_attach_backing,
-            virtio_gpu_resource_detach_backing, virtio_gpu_resource_flush, virtio_gpu_set_scanout,
+            virtio_gpu_get_capset_info, virtio_gpu_mem_entry, virtio_gpu_rect,
+            virtio_gpu_resource_attach_backing, virtio_gpu_resource_detach_backing,
+            virtio_gpu_resource_flush, virtio_gpu_resource_unref, virtio_gpu_set_scanout,
             GpuResponse::{OkCapsetInfo, OkDisplayInfo, OkEdid, OkNoData},
             VIRTIO_GPU_CMD_CTX_ATTACH_RESOURCE, VIRTIO_GPU_CMD_CTX_CREATE,
             VIRTIO_GPU_CMD_CTX_DESTROY, VIRTIO_GPU_CMD_CTX_DETACH_RESOURCE,
@@ -808,7 +809,7 @@ mod tests {
         });
         assert_matches!(result, Ok(OkDisplayInfo(_)));
 
-        let cmd = GpuCommand::GetEdid(Default::default());
+        let cmd = GpuCommand::GetEdid(virtio_gpu_get_edid::default());
         let result = test_cmd(cmd, |g| {
             g.expect_get_edid().return_once(|_| {
                 Ok(OkEdid {
@@ -818,52 +819,55 @@ mod tests {
         });
         assert_matches!(result, Ok(OkEdid { .. }));
 
-        let cmd = GpuCommand::ResourceCreate2d(Default::default());
+        let cmd = GpuCommand::ResourceCreate2d(virtio_gpu_resource_create_2d::default());
         let result = test_cmd(cmd, |g| {
             g.expect_resource_create_3d()
                 .return_once(|_, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::ResourceUnref(Default::default());
+        let cmd = GpuCommand::ResourceUnref(virtio_gpu_resource_unref::default());
         let result = test_cmd(cmd, |g| {
             g.expect_unref_resource().return_once(|_| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::SetScanout(Default::default());
+        let cmd = GpuCommand::SetScanout(virtio_gpu_set_scanout::default());
         let result = test_cmd(cmd, |g| {
             g.expect_set_scanout().return_once(|_, _, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::ResourceFlush(Default::default());
+        let cmd = GpuCommand::ResourceFlush(virtio_gpu_resource_flush::default());
         let result = test_cmd(cmd, |g| {
             g.expect_flush_resource().return_once(|_, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::TransferToHost2d(Default::default());
+        let cmd = GpuCommand::TransferToHost2d(virtio_gpu_transfer_to_host_2d::default());
         let result = test_cmd(cmd, |g| {
             g.expect_transfer_write()
                 .return_once(|_, _, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::ResourceAttachBacking(Default::default(), Default::default());
+        let cmd = GpuCommand::ResourceAttachBacking(
+            virtio_gpu_resource_attach_backing::default(),
+            Vec::default(),
+        );
         let result = test_cmd(cmd, |g| {
             g.expect_attach_backing()
                 .return_once(|_, _, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::ResourceDetachBacking(Default::default());
+        let cmd = GpuCommand::ResourceDetachBacking(virtio_gpu_resource_detach_backing::default());
         let result = test_cmd(cmd, |g| {
             g.expect_detach_backing().return_once(|_| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::GetCapsetInfo(Default::default());
+        let cmd = GpuCommand::GetCapsetInfo(virtio_gpu_get_capset_info::default());
         let result = test_cmd(cmd, |g| {
             g.expect_get_capset_info().return_once(|_| {
                 Ok(OkCapsetInfo {
@@ -882,48 +886,48 @@ mod tests {
             })
         );
 
-        let cmd = GpuCommand::CtxCreate(Default::default());
+        let cmd = GpuCommand::CtxCreate(virtio_gpu_ctx_create::default());
         let result = test_cmd(cmd, |g| {
             g.expect_create_context()
                 .return_once(|_, _, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::CtxDestroy(Default::default());
+        let cmd = GpuCommand::CtxDestroy(virtio_gpu_ctx_destroy::default());
         let result = test_cmd(cmd, |g| {
             g.expect_destroy_context().return_once(|_| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::CtxAttachResource(Default::default());
+        let cmd = GpuCommand::CtxAttachResource(virtio_gpu_ctx_resource::default());
         let result = test_cmd(cmd, |g| {
             g.expect_context_attach_resource()
                 .return_once(|_, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::CtxDetachResource(Default::default());
+        let cmd = GpuCommand::CtxDetachResource(virtio_gpu_ctx_resource::default());
         let result = test_cmd(cmd, |g| {
             g.expect_context_detach_resource()
                 .return_once(|_, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::ResourceCreate3d(Default::default());
+        let cmd = GpuCommand::ResourceCreate3d(virtio_gpu_resource_create_3d::default());
         let result = test_cmd(cmd, |g| {
             g.expect_resource_create_3d()
                 .return_once(|_, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::TransferToHost3d(Default::default());
+        let cmd = GpuCommand::TransferToHost3d(virtio_gpu_transfer_host_3d::default());
         let result = test_cmd(cmd, |g| {
             g.expect_transfer_write()
                 .return_once(|_, _, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::TransferFromHost3d(Default::default());
+        let cmd = GpuCommand::TransferFromHost3d(virtio_gpu_transfer_host_3d::default());
         let result = test_cmd(cmd, |g| {
             g.expect_transfer_read()
                 .return_once(|_, _, _, _| Ok(OkNoData));
@@ -940,20 +944,20 @@ mod tests {
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::UpdateCursor(Default::default());
+        let cmd = GpuCommand::UpdateCursor(virtio_gpu_update_cursor::default());
         let result = test_cmd(cmd, |g| {
             g.expect_update_cursor()
                 .return_once(|_, _, _, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::MoveCursor(Default::default());
+        let cmd = GpuCommand::MoveCursor(virtio_gpu_update_cursor::default());
         let result = test_cmd(cmd, |g| {
             g.expect_move_cursor().return_once(|_, _| Ok(OkNoData));
         });
         assert_matches!(result, Ok(OkNoData));
 
-        let cmd = GpuCommand::MoveCursor(Default::default());
+        let cmd = GpuCommand::MoveCursor(virtio_gpu_update_cursor::default());
         let result = test_cmd(cmd, |g| {
             g.expect_move_cursor().return_once(|_, _| Ok(OkNoData));
         });
@@ -1175,11 +1179,11 @@ mod tests {
 
     #[test]
     fn test_command_with_fence_ready_immediately() {
+        const FENCE_ID: u64 = 123;
+
         let (backend, mem) = init();
         backend.update_memory(mem.clone()).unwrap();
         let backend_inner = backend.inner.lock().unwrap();
-
-        const FENCE_ID: u64 = 123;
 
         let hdr = virtio_gpu_ctrl_hdr {
             type_: VIRTIO_GPU_CMD_TRANSFER_TO_HOST_3D.into(),
@@ -1258,13 +1262,13 @@ mod tests {
 
     #[test]
     fn test_command_with_fence_not_ready() {
-        let (backend, mem) = init();
-        backend.update_memory(mem.clone()).unwrap();
-        let backend_inner = backend.inner.lock().unwrap();
-
         const FENCE_ID: u64 = 123;
         const CTX_ID: u32 = 1;
         const RING_IDX: u8 = 2;
+
+        let (backend, mem) = init();
+        backend.update_memory(mem.clone()).unwrap();
+        let backend_inner = backend.inner.lock().unwrap();
 
         let hdr = virtio_gpu_ctrl_hdr {
             type_: VIRTIO_GPU_CMD_TRANSFER_FROM_HOST_3D.into(),
@@ -1343,7 +1347,7 @@ mod tests {
 
             assert_eq!(backend.num_queues(), NUM_QUEUES);
             assert_eq!(backend.max_queue_size(), QUEUE_SIZE);
-            assert_eq!(backend.features(), 0x1017100001B);
+            assert_eq!(backend.features(), 0x0101_7100_001B);
             assert_eq!(
                 backend.protocol_features(),
                 VhostUserProtocolFeatures::CONFIG | VhostUserProtocolFeatures::MQ
@@ -1399,8 +1403,8 @@ mod tests {
 
     mod test_image {
         use super::*;
-        const GREEN_PIXEL: u32 = 0x00FF00FF;
-        const RED_PIXEL: u32 = 0xFF0000FF;
+        const GREEN_PIXEL: u32 = 0x00FF_00FF;
+        const RED_PIXEL: u32 = 0x00FF_00FF;
         const BYTES_PER_PIXEL: usize = 4;
 
         pub fn write(mem: &GuestMemoryMmap, image_addr: GuestAddress, width: u32, height: u32) {
@@ -1442,7 +1446,7 @@ mod tests {
             entries.push(virtio_gpu_mem_entry {
                 addr: addr.into(),
                 length: chunk_size.into(),
-                padding: Default::default(),
+                padding: Le32::default(),
             });
             addr += u64::from(chunk_size);
             remaining -= chunk_size;
@@ -1452,8 +1456,8 @@ mod tests {
             entries.push(virtio_gpu_mem_entry {
                 addr: addr.into(),
                 length: remaining.into(),
-                padding: Default::default(),
-            })
+                padding: Le32::default(),
+            });
         }
 
         entries
@@ -1471,6 +1475,24 @@ mod tests {
         /// then present the display output.
         #[test]
         fn test_display_output() {
+            const IMAGE_ADDR: GuestAddress = GuestAddress(0x30_000);
+            const IMAGE_WIDTH: u32 = 640;
+            const IMAGE_HEIGHT: u32 = 480;
+            const RESP_SIZE: u32 = mem::size_of::<virtio_gpu_ctrl_hdr>() as u32;
+            const EXPECTED_SCANOUT_REQUEST: VhostUserGpuScanout = VhostUserGpuScanout {
+                scanout_id: 1,
+                width: IMAGE_WIDTH,
+                height: IMAGE_HEIGHT,
+            };
+
+            const EXPECTED_UPDATE_REQUEST: VhostUserGpuUpdate = VhostUserGpuUpdate {
+                scanout_id: 1,
+                x: 0,
+                y: 0,
+                width: IMAGE_WIDTH,
+                height: IMAGE_HEIGHT,
+            };
+
             let (backend, mem) = init();
             let (mut gpu_frontend, gpu_backend) = gpu_backend_pair();
             gpu_frontend
@@ -1493,11 +1515,6 @@ mod tests {
             let epoll_handlers = daemon.get_epoll_handlers();
             backend.set_epoll_handler(&epoll_handlers);
             mem::drop(daemon);
-
-            const IMAGE_ADDR: GuestAddress = GuestAddress(0x30_000);
-            const IMAGE_WIDTH: u32 = 640;
-            const IMAGE_HEIGHT: u32 = 480;
-            const RESP_SIZE: u32 = mem::size_of::<virtio_gpu_ctrl_hdr>() as u32;
 
             let image_rect = virtio_gpu_rect {
                 x: 0.into(),
@@ -1527,7 +1544,7 @@ mod tests {
                 nr_entries: (mem_entries.len() as u32).into(),
             };
             let mut readable_desc_bufs = vec![hdr.as_slice(), cmd.as_slice()];
-            readable_desc_bufs.extend(mem_entries.iter().map(|entry| entry.as_slice()));
+            readable_desc_bufs.extend(mem_entries.iter().map(ByteValued::as_slice));
             let attach_backing_cmd = TestingDescChainArgs {
                 readable_desc_bufs: &readable_desc_bufs,
                 writable_desc_lengths: &[RESP_SIZE],
@@ -1537,7 +1554,7 @@ mod tests {
             let hdr = new_hdr(VIRTIO_GPU_CMD_RESOURCE_DETACH_BACKING);
             let cmd = virtio_gpu_resource_detach_backing {
                 resource_id: 1.into(),
-                padding: Default::default(),
+                padding: Le32::default(),
             };
             let detach_backing_cmd = TestingDescChainArgs {
                 readable_desc_bufs: &[hdr.as_slice(), cmd.as_slice()],
@@ -1550,7 +1567,7 @@ mod tests {
                 r: image_rect,
                 offset: 0.into(),
                 resource_id: 1.into(),
-                padding: Default::default(),
+                padding: Le32::default(),
             };
             let transfer_to_host_cmd = TestingDescChainArgs {
                 readable_desc_bufs: &[hdr.as_slice(), cmd.as_slice()],
@@ -1614,7 +1631,7 @@ mod tests {
             let cmd = virtio_gpu_resource_flush {
                 r: image_rect,
                 resource_id: 1.into(),
-                padding: Default::default(),
+                padding: Le32::default(),
             };
             let flush_resource_cmd = TestingDescChainArgs {
                 readable_desc_bufs: &[hdr.as_slice(), cmd.as_slice()],
@@ -1642,20 +1659,6 @@ mod tests {
 
             // Write the test image in guest memory
             test_image::write(&mem.memory(), IMAGE_ADDR, IMAGE_WIDTH, IMAGE_HEIGHT);
-
-            const EXPECTED_SCANOUT_REQUEST: VhostUserGpuScanout = VhostUserGpuScanout {
-                scanout_id: 1,
-                width: IMAGE_WIDTH,
-                height: IMAGE_HEIGHT,
-            };
-
-            const EXPECTED_UPDATE_REQUEST: VhostUserGpuUpdate = VhostUserGpuUpdate {
-                scanout_id: 1,
-                x: 0,
-                y: 0,
-                width: IMAGE_WIDTH,
-                height: IMAGE_HEIGHT,
-            };
 
             // This simulates the frontend vmm. Here we check the issued frontend requests and if the
             // output matches the test image.

--- a/staging/vhost-device-gpu/src/lib.rs
+++ b/staging/vhost-device-gpu/src/lib.rs
@@ -49,6 +49,7 @@ use clap::ValueEnum;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum GpuMode {
     VirglRenderer,
+    #[cfg(feature = "gfxstream")]
     Gfxstream,
 }
 

--- a/staging/vhost-device-gpu/src/lib.rs
+++ b/staging/vhost-device-gpu/src/lib.rs
@@ -39,27 +39,22 @@ pub mod device;
 pub mod protocol;
 pub mod virtio_gpu;
 
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::{Display, Formatter},
+    path::Path,
+};
 
+use bitflags::bitflags;
 use clap::ValueEnum;
 use log::info;
+#[cfg(feature = "gfxstream")]
+use rutabaga_gfx::{RUTABAGA_CAPSET_GFXSTREAM_GLES, RUTABAGA_CAPSET_GFXSTREAM_VULKAN};
+use rutabaga_gfx::{RUTABAGA_CAPSET_VIRGL, RUTABAGA_CAPSET_VIRGL2};
 use thiserror::Error as ThisError;
 use vhost_user_backend::VhostUserDaemon;
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 
 use crate::device::VhostUserGpuBackend;
-
-type Result<T> = std::result::Result<T, Error>;
-
-#[derive(Debug, ThisError)]
-pub enum Error {
-    #[error("Could not create backend: {0}")]
-    CouldNotCreateBackend(device::Error),
-    #[error("Could not create daemon: {0}")]
-    CouldNotCreateDaemon(vhost_user_backend::Error),
-    #[error("Fatal error: {0}")]
-    ServeFailed(vhost_user_backend::Error),
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum GpuMode {
@@ -69,51 +64,194 @@ pub enum GpuMode {
     Gfxstream,
 }
 
+impl Display for GpuMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::VirglRenderer => write!(f, "virglrenderer"),
+            #[cfg(feature = "gfxstream")]
+            Self::Gfxstream => write!(f, "gfxstream"),
+        }
+    }
+}
+
+bitflags! {
+    /// A bitmask for representing supported gpu capability sets.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct GpuCapset: u64 {
+        const VIRGL = 1 << RUTABAGA_CAPSET_VIRGL as u64;
+        const VIRGL2 = 1 << RUTABAGA_CAPSET_VIRGL2 as u64;
+        const ALL_VIRGLRENDERER_CAPSETS = Self::VIRGL.bits() | Self::VIRGL2.bits();
+
+        #[cfg(feature = "gfxstream")]
+        const GFXSTREAM_VULKAN = 1 << RUTABAGA_CAPSET_GFXSTREAM_VULKAN as u64;
+        #[cfg(feature = "gfxstream")]
+        const GFXSTREAM_GLES = 1 << RUTABAGA_CAPSET_GFXSTREAM_GLES as u64;
+        #[cfg(feature = "gfxstream")]
+        const ALL_GFXSTREAM_CAPSETS = Self::GFXSTREAM_VULKAN.bits() | Self::GFXSTREAM_GLES.bits();
+    }
+}
+
+impl Display for GpuCapset {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut first = true;
+        for capset in self.iter() {
+            if !first {
+                write!(f, ", ")?;
+            }
+            first = false;
+
+            match capset {
+                Self::VIRGL => write!(f, "virgl"),
+                Self::VIRGL2 => write!(f, "virgl2"),
+                #[cfg(feature = "gfxstream")]
+                Self::GFXSTREAM_VULKAN => write!(f, "gfxstream-vulkan"),
+                #[cfg(feature = "gfxstream")]
+                Self::GFXSTREAM_GLES => write!(f, "gfxstream-gles"),
+                _ => panic!("Unknown capset {:#x}", self.bits()),
+            }?;
+        }
+
+        Ok(())
+    }
+}
+
+impl GpuCapset {
+    /// Return the number of enabled capsets
+    pub const fn num_capsets(self) -> u32 {
+        self.bits().count_ones()
+    }
+}
+
 #[derive(Debug, Clone)]
-/// This structure holds the internal configuration for the GPU backend,
-/// derived from the command-line arguments provided through `GpuArgs`.
+/// This structure holds the configuration for the GPU backend
 pub struct GpuConfig {
-    /// vhost-user Unix domain socket
-    socket_path: PathBuf,
     gpu_mode: GpuMode,
+    capset: GpuCapset,
+    flags: GpuFlags,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuFlags {
+    pub use_egl: bool,
+    pub use_glx: bool,
+    pub use_gles: bool,
+    pub use_surfaceless: bool,
+}
+
+impl GpuFlags {
+    // `const` version of `default()`
+    pub const fn new_default() -> Self {
+        Self {
+            use_egl: true,
+            use_glx: false,
+            use_gles: true,
+            use_surfaceless: true,
+        }
+    }
+}
+
+impl Default for GpuFlags {
+    fn default() -> Self {
+        Self::new_default()
+    }
+}
+
+#[derive(Debug, ThisError)]
+pub enum GpuConfigError {
+    #[error("The mode {0} does not support {1} capset")]
+    CapsetUnsuportedByMode(GpuMode, GpuCapset),
+    #[error("Requested gfxstream-gles capset, but gles is disabled")]
+    GlesRequiredByGfxstream,
 }
 
 impl GpuConfig {
-    /// Create a new instance of the `GpuConfig` struct, containing the
-    /// parameters to be fed into the gpu-backend server.
-    pub const fn new(socket_path: PathBuf, gpu_mode: GpuMode) -> Self {
-        Self {
-            socket_path,
-            gpu_mode,
+    pub const DEFAULT_VIRGLRENDER_CAPSET_MASK: GpuCapset = GpuCapset::ALL_VIRGLRENDERER_CAPSETS;
+
+    #[cfg(feature = "gfxstream")]
+    pub const DEFAULT_GFXSTREAM_CAPSET_MASK: GpuCapset = GpuCapset::ALL_GFXSTREAM_CAPSETS;
+
+    pub const fn get_default_capset_for_mode(gpu_mode: GpuMode) -> GpuCapset {
+        match gpu_mode {
+            GpuMode::VirglRenderer => Self::DEFAULT_VIRGLRENDER_CAPSET_MASK,
+            #[cfg(feature = "gfxstream")]
+            GpuMode::Gfxstream => Self::DEFAULT_GFXSTREAM_CAPSET_MASK,
         }
     }
 
-    /// Return the path of the unix domain socket which is listening to
-    /// requests from the guest.
-    pub fn socket_path(&self) -> &Path {
-        &self.socket_path
+    fn validate_capset(gpu_mode: GpuMode, capset: GpuCapset) -> Result<(), GpuConfigError> {
+        let supported_capset_mask = match gpu_mode {
+            GpuMode::VirglRenderer => GpuCapset::ALL_VIRGLRENDERER_CAPSETS,
+            #[cfg(feature = "gfxstream")]
+            GpuMode::Gfxstream => GpuCapset::ALL_GFXSTREAM_CAPSETS,
+        };
+        for capset in capset.iter() {
+            if !supported_capset_mask.contains(capset) {
+                return Err(GpuConfigError::CapsetUnsuportedByMode(gpu_mode, capset));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Create a new instance of the `GpuConfig` struct, containing the
+    /// parameters to be fed into the gpu-backend server.
+    pub fn new(
+        gpu_mode: GpuMode,
+        capset: Option<GpuCapset>,
+        flags: GpuFlags,
+    ) -> Result<Self, GpuConfigError> {
+        let capset = capset.unwrap_or_else(|| Self::get_default_capset_for_mode(gpu_mode));
+        Self::validate_capset(gpu_mode, capset)?;
+
+        #[cfg(feature = "gfxstream")]
+        if capset.contains(GpuCapset::GFXSTREAM_GLES) && !flags.use_gles {
+            return Err(GpuConfigError::GlesRequiredByGfxstream);
+        }
+
+        Ok(Self {
+            gpu_mode,
+            capset,
+            flags,
+        })
     }
 
     pub const fn gpu_mode(&self) -> GpuMode {
         self.gpu_mode
     }
+
+    pub const fn capsets(&self) -> GpuCapset {
+        self.capset
+    }
+
+    pub const fn flags(&self) -> &GpuFlags {
+        &self.flags
+    }
 }
 
-pub fn start_backend(config: &GpuConfig) -> Result<()> {
+#[derive(Debug, ThisError)]
+pub enum StartError {
+    #[error("Could not create backend: {0}")]
+    CouldNotCreateBackend(device::Error),
+    #[error("Could not create daemon: {0}")]
+    CouldNotCreateDaemon(vhost_user_backend::Error),
+    #[error("Fatal error: {0}")]
+    ServeFailed(vhost_user_backend::Error),
+}
+
+pub fn start_backend(socket_path: &Path, config: GpuConfig) -> Result<(), StartError> {
     info!("Starting backend");
-    let socket = config.socket_path();
-    let backend = VhostUserGpuBackend::new(config).map_err(Error::CouldNotCreateBackend)?;
+    let backend = VhostUserGpuBackend::new(config).map_err(StartError::CouldNotCreateBackend)?;
 
     let mut daemon = VhostUserDaemon::new(
         "vhost-device-gpu-backend".to_string(),
         backend.clone(),
         GuestMemoryAtomic::new(GuestMemoryMmap::new()),
     )
-    .map_err(Error::CouldNotCreateDaemon)?;
+    .map_err(StartError::CouldNotCreateDaemon)?;
 
     backend.set_epoll_handler(&daemon.get_epoll_handlers());
 
-    daemon.serve(socket).map_err(Error::ServeFailed)?;
+    daemon.serve(socket_path).map_err(StartError::ServeFailed)?;
     Ok(())
 }
 
@@ -121,26 +259,111 @@ pub fn start_backend(config: &GpuConfig) -> Result<()> {
 mod tests {
     use std::path::Path;
 
+    #[cfg(feature = "gfxstream")]
     use assert_matches::assert_matches;
-    use tempfile::tempdir;
+    use clap::ValueEnum;
 
     use super::*;
 
     #[test]
-    fn test_gpu_config() {
-        // Test the creation of `GpuConfig` struct
-        let test_dir = tempdir().expect("Could not create a temp test directory.");
-        let socket_path = test_dir.path().join("socket");
-        let gpu_config = GpuConfig::new(socket_path.clone(), GpuMode::VirglRenderer);
-        assert_eq!(gpu_config.socket_path(), socket_path);
+    fn test_gpu_config_create_default_virglrenderer() {
+        let config = GpuConfig::new(GpuMode::VirglRenderer, None, GpuFlags::new_default()).unwrap();
+        assert_eq!(config.gpu_mode(), GpuMode::VirglRenderer);
+        assert_eq!(config.capsets(), GpuConfig::DEFAULT_VIRGLRENDER_CAPSET_MASK);
+    }
+
+    #[test]
+    #[cfg(feature = "gfxstream")]
+    fn test_gpu_config_create_default_gfxstream() {
+        let config = GpuConfig::new(GpuMode::Gfxstream, None, GpuFlags::default()).unwrap();
+        assert_eq!(config.gpu_mode(), GpuMode::Gfxstream);
+        assert_eq!(config.capsets(), GpuConfig::DEFAULT_GFXSTREAM_CAPSET_MASK);
+    }
+
+    #[cfg(feature = "gfxstream")]
+    fn assert_invalid_gpu_config(mode: GpuMode, capset: GpuCapset, expected_capset: GpuCapset) {
+        let result = GpuConfig::new(mode, Some(capset), GpuFlags::new_default());
+        assert_matches!(
+            result,
+            Err(GpuConfigError::CapsetUnsuportedByMode(
+                requested_mode,
+                unsupported_capset
+            )) if unsupported_capset == expected_capset && requested_mode == mode
+        );
+    }
+
+    #[test]
+    fn test_gpu_config_valid_combination() {
+        let config = GpuConfig::new(
+            GpuMode::VirglRenderer,
+            Some(GpuCapset::VIRGL2),
+            GpuFlags::default(),
+        )
+        .unwrap();
+        assert_eq!(config.gpu_mode(), GpuMode::VirglRenderer);
+    }
+
+    #[test]
+    #[cfg(feature = "gfxstream")]
+    fn test_gpu_config_invalid_combinations() {
+        assert_invalid_gpu_config(
+            GpuMode::VirglRenderer,
+            GpuCapset::VIRGL2 | GpuCapset::GFXSTREAM_VULKAN,
+            GpuCapset::GFXSTREAM_VULKAN,
+        );
+
+        assert_invalid_gpu_config(
+            GpuMode::Gfxstream,
+            GpuCapset::VIRGL2 | GpuCapset::GFXSTREAM_VULKAN,
+            GpuCapset::VIRGL2,
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "gfxstream")]
+    fn test_gles_required_by_gfxstream() {
+        let capset = GpuCapset::GFXSTREAM_VULKAN | GpuCapset::GFXSTREAM_GLES;
+        let flags = GpuFlags {
+            use_gles: false,
+            ..GpuFlags::new_default()
+        };
+        let result = GpuConfig::new(GpuMode::Gfxstream, Some(capset), flags);
+        assert_matches!(result, Err(GpuConfigError::GlesRequiredByGfxstream));
+    }
+
+    #[test]
+    fn test_default_num_capsets() {
+        assert_eq!(GpuConfig::DEFAULT_VIRGLRENDER_CAPSET_MASK.num_capsets(), 2);
+        #[cfg(feature = "gfxstream")]
+        assert_eq!(GpuConfig::DEFAULT_GFXSTREAM_CAPSET_MASK.num_capsets(), 2);
+    }
+
+    #[test]
+    fn test_capset_display_multiple() {
+        let capset = GpuCapset::VIRGL | GpuCapset::VIRGL2;
+        let output = capset.to_string();
+        assert_eq!(output, "virgl, virgl2")
+    }
+
+    /// Check if display name of GpuMode is the same as the name in the CLI arg
+    #[test]
+    fn test_gpu_mode_display_eq_arg_name() {
+        for mode in GpuMode::value_variants() {
+            let mode_str = mode.to_string();
+            let mode_from_str = GpuMode::from_str(&mode_str, false);
+            assert_eq!(*mode, mode_from_str.unwrap());
+        }
     }
 
     #[test]
     fn test_fail_listener() {
         // This will fail the listeners and thread will panic.
         let socket_name = Path::new("/proc/-1/nonexistent");
-        let config = GpuConfig::new(socket_name.into(), GpuMode::VirglRenderer);
+        let config = GpuConfig::new(GpuMode::VirglRenderer, None, GpuFlags::default()).unwrap();
 
-        assert_matches!(start_backend(&config).unwrap_err(), Error::ServeFailed(_));
+        assert_matches!(
+            start_backend(socket_name, config).unwrap_err(),
+            StartError::ServeFailed(_)
+        );
     }
 }

--- a/staging/vhost-device-gpu/src/lib.rs
+++ b/staging/vhost-device-gpu/src/lib.rs
@@ -35,11 +35,8 @@
     clippy::significant_drop_tightening
 )]
 
-#[cfg(target_env = "gnu")]
 pub mod device;
-#[cfg(target_env = "gnu")]
 pub mod protocol;
-#[cfg(target_env = "gnu")]
 pub mod virtio_gpu;
 
 use std::path::{Path, PathBuf};

--- a/staging/vhost-device-gpu/src/lib.rs
+++ b/staging/vhost-device-gpu/src/lib.rs
@@ -48,6 +48,7 @@ use clap::ValueEnum;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum GpuMode {
+    #[value(name = "virglrenderer", alias("virgl-renderer"))]
     VirglRenderer,
     #[cfg(feature = "gfxstream")]
     Gfxstream,

--- a/staging/vhost-device-gpu/src/main.rs
+++ b/staging/vhost-device-gpu/src/main.rs
@@ -4,92 +4,76 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
-// Rust vmm container (https://github.com/rust-vmm/rust-vmm-container) doesn't
-// have tools to do a musl build at the moment, and adding that support is
-// tricky as well to the container. Skip musl builds until the time pre-built
-// rutabaga library is available for musl.
-#[cfg(target_env = "gnu")]
-pub mod gnu_main {
-    use std::{path::PathBuf, process::exit};
+use std::{path::PathBuf, process::exit};
 
-    use clap::Parser;
-    use log::{error, info};
-    use thiserror::Error as ThisError;
-    use vhost_device_gpu::{
-        device::{self, VhostUserGpuBackend},
-        GpuConfig, GpuMode,
-    };
-    use vhost_user_backend::VhostUserDaemon;
-    use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+use clap::Parser;
+use log::{error, info};
+use thiserror::Error as ThisError;
+use vhost_device_gpu::{
+    device::{self, VhostUserGpuBackend},
+    GpuConfig, GpuMode,
+};
+use vhost_user_backend::VhostUserDaemon;
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 
-    type Result<T> = std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
-    #[derive(Debug, ThisError)]
-    pub enum Error {
-        #[error("Could not create backend: {0}")]
-        CouldNotCreateBackend(device::Error),
-        #[error("Could not create daemon: {0}")]
-        CouldNotCreateDaemon(vhost_user_backend::Error),
-        #[error("Fatal error: {0}")]
-        ServeFailed(vhost_user_backend::Error),
-    }
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("Could not create backend: {0}")]
+    CouldNotCreateBackend(device::Error),
+    #[error("Could not create daemon: {0}")]
+    CouldNotCreateDaemon(vhost_user_backend::Error),
+    #[error("Fatal error: {0}")]
+    ServeFailed(vhost_user_backend::Error),
+}
 
-    #[derive(Parser, Debug)]
-    #[clap(author, version, about, long_about = None)]
-    pub struct GpuArgs {
-        /// vhost-user Unix domain socket.
-        #[clap(short, long, value_name = "SOCKET")]
-        pub socket_path: PathBuf,
-        #[clap(short, long, value_enum)]
-        pub gpu_mode: GpuMode,
-    }
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct GpuArgs {
+    /// vhost-user Unix domain socket.
+    #[clap(short, long, value_name = "SOCKET")]
+    pub socket_path: PathBuf,
+    #[clap(short, long, value_enum)]
+    pub gpu_mode: GpuMode,
+}
 
-    impl From<GpuArgs> for GpuConfig {
-        fn from(args: GpuArgs) -> Self {
-            let socket_path = args.socket_path;
-            let gpu_mode: GpuMode = args.gpu_mode;
+impl From<GpuArgs> for GpuConfig {
+    fn from(args: GpuArgs) -> Self {
+        let socket_path = args.socket_path;
+        let gpu_mode: GpuMode = args.gpu_mode;
 
-            GpuConfig::new(socket_path, gpu_mode)
-        }
-    }
-
-    pub fn start_backend(config: &GpuConfig) -> Result<()> {
-        info!("Starting backend");
-        let socket = config.socket_path();
-        let backend = VhostUserGpuBackend::new(config).map_err(Error::CouldNotCreateBackend)?;
-
-        let mut daemon = VhostUserDaemon::new(
-            "vhost-device-gpu-backend".to_string(),
-            backend.clone(),
-            GuestMemoryAtomic::new(GuestMemoryMmap::new()),
-        )
-        .map_err(Error::CouldNotCreateDaemon)?;
-
-        backend.set_epoll_handler(&daemon.get_epoll_handlers());
-
-        daemon.serve(socket).map_err(Error::ServeFailed)?;
-        Ok(())
-    }
-
-    pub fn main() {
-        env_logger::init();
-
-        if let Err(e) = start_backend(&GpuConfig::from(GpuArgs::parse())) {
-            error!("{e}");
-            exit(1);
-        }
+        GpuConfig::new(socket_path, gpu_mode)
     }
 }
 
-#[cfg(target_env = "gnu")]
+pub fn start_backend(config: &GpuConfig) -> Result<()> {
+    info!("Starting backend");
+    let socket = config.socket_path();
+    let backend = VhostUserGpuBackend::new(config).map_err(Error::CouldNotCreateBackend)?;
+
+    let mut daemon = VhostUserDaemon::new(
+        "vhost-device-gpu-backend".to_string(),
+        backend.clone(),
+        GuestMemoryAtomic::new(GuestMemoryMmap::new()),
+    )
+    .map_err(Error::CouldNotCreateDaemon)?;
+
+    backend.set_epoll_handler(&daemon.get_epoll_handlers());
+
+    daemon.serve(socket).map_err(Error::ServeFailed)?;
+    Ok(())
+}
+
 fn main() {
-    gnu_main::main();
+    env_logger::init();
+
+    if let Err(e) = start_backend(&GpuConfig::from(GpuArgs::parse())) {
+        error!("{e}");
+        exit(1);
+    }
 }
 
-#[cfg(target_env = "musl")]
-fn main() {}
-
-#[cfg(target_env = "gnu")]
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -98,7 +82,7 @@ mod tests {
     use tempfile::tempdir;
     use vhost_device_gpu::{GpuConfig, GpuMode};
 
-    use super::gnu_main::{start_backend, Error, GpuArgs};
+    use super::{start_backend, Error, GpuArgs};
 
     impl GpuArgs {
         pub(crate) fn from_args(path: &Path) -> Self {

--- a/staging/vhost-device-gpu/src/main.rs
+++ b/staging/vhost-device-gpu/src/main.rs
@@ -6,9 +6,45 @@
 
 use std::{path::PathBuf, process::exit};
 
-use clap::Parser;
+use clap::{ArgAction, Parser, ValueEnum};
 use log::error;
-use vhost_device_gpu::{start_backend, GpuConfig, GpuMode};
+use vhost_device_gpu::{start_backend, GpuCapset, GpuConfig, GpuConfigError, GpuFlags, GpuMode};
+
+#[derive(ValueEnum, Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u64)]
+pub enum CapsetName {
+    /// [virglrenderer] OpenGL implementation, superseded by Virgl2
+    Virgl = GpuCapset::VIRGL.bits(),
+
+    /// [virglrenderer] OpenGL implementation
+    Virgl2 = GpuCapset::VIRGL2.bits(),
+
+    /// [gfxstream] Vulkan implementation (partial support only){n}
+    /// NOTE: Can only be used for 2D display output for now, there is no
+    /// hardware acceleration yet
+    #[cfg(feature = "gfxstream")]
+    GfxstreamVulkan = GpuCapset::GFXSTREAM_VULKAN.bits(),
+
+    /// [gfxstream] OpenGL ES implementation (partial support only){n}
+    /// NOTE: Can only be used for 2D display output for now, there is no
+    /// hardware acceleration yet
+    #[cfg(feature = "gfxstream")]
+    GfxstreamGles = GpuCapset::GFXSTREAM_GLES.bits(),
+}
+
+impl From<CapsetName> for GpuCapset {
+    fn from(capset_name: CapsetName) -> GpuCapset {
+        GpuCapset::from_bits(capset_name as u64)
+            .expect("Internal error: CapsetName enum is incorrectly defined")
+    }
+}
+
+pub fn capset_names_into_capset(capset_names: impl IntoIterator<Item = CapsetName>) -> GpuCapset {
+    capset_names
+        .into_iter()
+        .map(CapsetName::into)
+        .fold(GpuCapset::empty(), GpuCapset::union)
+}
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -16,23 +52,87 @@ pub struct GpuArgs {
     /// vhost-user Unix domain socket.
     #[clap(short, long, value_name = "SOCKET")]
     pub socket_path: PathBuf,
+
+    /// The mode specifies which backend implementation to use
     #[clap(short, long, value_enum)]
     pub gpu_mode: GpuMode,
+
+    /// Comma separated list of enabled capsets
+    #[clap(short, long, value_delimiter = ',')]
+    pub capset: Option<Vec<CapsetName>>,
+
+    #[clap(flatten)]
+    pub flags: GpuFlagsArgs,
 }
 
-impl From<GpuArgs> for GpuConfig {
-    fn from(args: GpuArgs) -> Self {
-        let socket_path = args.socket_path;
-        let gpu_mode: GpuMode = args.gpu_mode;
+#[derive(Parser, Debug)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct GpuFlagsArgs {
+    /// Enable backend to use EGL
+    #[clap(
+            long,
+            action = ArgAction::Set,
+            default_value_t = GpuFlags::new_default().use_egl
+    )]
+    pub use_egl: bool,
 
-        GpuConfig::new(socket_path, gpu_mode)
+    /// Enable backend to use GLX
+    #[clap(
+            long,
+            action = ArgAction::Set,
+            default_value_t = GpuFlags::new_default().use_glx
+    )]
+    pub use_glx: bool,
+
+    /// Enable backend to use GLES
+    #[clap(
+            long,
+            action = ArgAction::Set,
+            default_value_t = GpuFlags::new_default().use_gles
+    )]
+    pub use_gles: bool,
+
+    /// Enable surfaceless backend option
+    #[clap(
+            long,
+            action = ArgAction::Set,
+            default_value_t = GpuFlags::new_default().use_surfaceless
+    )]
+    pub use_surfaceless: bool,
+}
+
+impl From<GpuFlagsArgs> for GpuFlags {
+    fn from(args: GpuFlagsArgs) -> Self {
+        GpuFlags {
+            use_egl: args.use_egl,
+            use_glx: args.use_glx,
+            use_gles: args.use_gles,
+            use_surfaceless: args.use_surfaceless,
+        }
     }
 }
 
-fn main() {
+pub fn config_from_args(args: GpuArgs) -> Result<(PathBuf, GpuConfig), GpuConfigError> {
+    let flags = GpuFlags::from(args.flags);
+    let capset = args.capset.map(capset_names_into_capset);
+    let config = GpuConfig::new(args.gpu_mode, capset, flags)?;
+    Ok((args.socket_path, config))
+}
+
+pub fn main() {
     env_logger::init();
 
-    if let Err(e) = start_backend(&GpuConfig::from(GpuArgs::parse())) {
+    let args = GpuArgs::parse();
+
+    let (socket_path, config) = match config_from_args(args) {
+        Ok(config) => config,
+        Err(e) => {
+            error!("{e}");
+            exit(1);
+        }
+    };
+
+    if let Err(e) = start_backend(&socket_path, config) {
         error!("{e}");
         exit(1);
     }
@@ -42,28 +142,65 @@ fn main() {
 mod tests {
     use std::path::Path;
 
-    use tempfile::tempdir;
-    use vhost_device_gpu::{GpuConfig, GpuMode};
+    use clap::{Parser, ValueEnum};
+    use vhost_device_gpu::{GpuCapset, GpuFlags, GpuMode};
 
     use super::*;
 
-    impl GpuArgs {
-        pub(crate) fn from_args(path: &Path) -> Self {
-            Self {
-                socket_path: path.to_path_buf(),
-                gpu_mode: GpuMode::Gfxstream,
-            }
+    #[test]
+    fn test_capset_enum_in_sync_with_capset_bitset() {
+        // Convert each GpuCapset into CapsetName
+        for capset in GpuCapset::all().iter() {
+            let display_name = capset.to_string();
+            let capset_name = CapsetName::from_str(&display_name, false).unwrap();
+            let resulting_capset: GpuCapset = capset_name.into();
+            assert_eq!(resulting_capset, capset);
+        }
+
+        // Convert each CapsetName into GpuCapset
+        for capset_name in CapsetName::value_variants().iter().cloned() {
+            let resulting_capset: GpuCapset = capset_name.into(); // Would panic! if the definition is incorrect
+            assert_eq!(resulting_capset.bits(), capset_name as u64)
         }
     }
 
     #[test]
-    fn test_parse_successful() {
-        let test_dir = tempdir().expect("Could not create a temp test directory.");
-        let socket_path = test_dir.path().join("vgpu.sock");
+    fn test_default_cli_flags() {
+        // The default CLI flags should match GpuFlags::default()
+        let args: &[&str] = &[];
+        let flag_args = GpuFlagsArgs::parse_from(args);
+        let flags: GpuFlags = flag_args.into();
+        assert_eq!(flags, GpuFlags::default());
+    }
 
-        let cmd_args = GpuArgs::from_args(socket_path.as_path());
-        let config = GpuConfig::from(cmd_args);
+    #[test]
+    fn test_config_from_args() {
+        let expected_path = Path::new("/some/test/path");
+        let args = GpuArgs {
+            socket_path: expected_path.into(),
+            gpu_mode: GpuMode::VirglRenderer,
+            capset: Some(vec![CapsetName::Virgl, CapsetName::Virgl2]),
+            flags: GpuFlagsArgs {
+                use_egl: false,
+                use_glx: true,
+                use_gles: false,
+                use_surfaceless: false,
+            },
+        };
 
-        assert_eq!(config.socket_path(), socket_path);
+        let (socket_path, config) = config_from_args(args).unwrap();
+
+        assert_eq!(socket_path, expected_path);
+        assert_eq!(
+            *config.flags(),
+            GpuFlags {
+                use_egl: false,
+                use_glx: true,
+                use_gles: false,
+                use_surfaceless: false,
+            }
+        );
+        assert_eq!(config.gpu_mode(), GpuMode::VirglRenderer);
+        assert_eq!(config.capsets(), GpuCapset::VIRGL | GpuCapset::VIRGL2)
     }
 }

--- a/staging/vhost-device-gpu/src/protocol.rs
+++ b/staging/vhost-device-gpu/src/protocol.rs
@@ -1171,25 +1171,25 @@ mod tests {
     #[test]
     fn test_invalid_command_type_display() {
         let error = InvalidCommandType(42);
-        assert_eq!(format!("{}", error), "Invalid command type 42");
+        assert_eq!(format!("{error}"), "Invalid command type 42");
     }
 
     #[test]
     fn test_gpu_response_display() {
         let err_rutabaga = GpuResponse::ErrRutabaga(RutabagaError::InvalidContextId);
         assert_eq!(
-            format!("{}", err_rutabaga),
+            format!("{err_rutabaga}"),
             "renderer error: invalid context id"
         );
 
         let err_scanout = GpuResponse::ErrScanout { num_scanouts: 3 };
-        assert_eq!(format!("{}", err_scanout), "non-zero scanout: 3");
+        assert_eq!(format!("{err_scanout}"), "non-zero scanout: 3");
     }
 
     #[test]
     fn test_invalid_type_error() {
         let error = GpuCommandDecodeError::InvalidType(42);
-        assert_eq!(format!("{}", error), "invalid command type (42)");
+        assert_eq!(format!("{error}"), "invalid command type (42)");
     }
 
     // Test io_error conversion to gpu command decode error
@@ -1313,7 +1313,7 @@ mod tests {
         ];
 
         for (command, expected) in test_cases {
-            assert_eq!(format!("{:?}", command), expected);
+            assert_eq!(format!("{command:?}"), expected);
         }
     }
 
@@ -1330,7 +1330,7 @@ mod tests {
             nlen: (bytes.len() as u32).into(),
         };
 
-        let debug_string = format!("{:?}", original);
+        let debug_string = format!("{original:?}");
         assert_eq!(
             debug_string,
             "virtio_gpu_ctx_create { debug_name: \"test_debug\", context_init: Le32(0), .. }"

--- a/staging/vhost-device-gpu/src/protocol.rs
+++ b/staging/vhost-device-gpu/src/protocol.rs
@@ -481,6 +481,7 @@ unsafe impl ByteValued for virtio_gpu_cmd_submit {}
 
 pub const VIRTIO_GPU_CAPSET_VIRGL: u32 = 1;
 pub const VIRTIO_GPU_CAPSET_VIRGL2: u32 = 2;
+#[cfg(feature = "gfxstream")]
 pub const VIRTIO_GPU_CAPSET_GFXSTREAM: u32 = 3;
 pub const VIRTIO_GPU_CAPSET_VENUS: u32 = 4;
 pub const VIRTIO_GPU_CAPSET_CROSS_DOMAIN: u32 = 5;

--- a/staging/vhost-device-gpu/src/protocol.rs
+++ b/staging/vhost-device-gpu/src/protocol.rs
@@ -479,13 +479,6 @@ pub struct virtio_gpu_cmd_submit {
 // reading its content from byte array.
 unsafe impl ByteValued for virtio_gpu_cmd_submit {}
 
-pub const VIRTIO_GPU_CAPSET_VIRGL: u32 = 1;
-pub const VIRTIO_GPU_CAPSET_VIRGL2: u32 = 2;
-#[cfg(feature = "gfxstream")]
-pub const VIRTIO_GPU_CAPSET_GFXSTREAM: u32 = 3;
-pub const VIRTIO_GPU_CAPSET_VENUS: u32 = 4;
-pub const VIRTIO_GPU_CAPSET_CROSS_DOMAIN: u32 = 5;
-
 // VIRTIO_GPU_CMD_GET_CAPSET_INFO
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(C)]

--- a/staging/vhost-device-gpu/src/virtio_gpu.rs
+++ b/staging/vhost-device-gpu/src/virtio_gpu.rs
@@ -945,8 +945,8 @@ mod tests {
         RutabagaVirtioGpu {
             rutabaga,
             gpu_backend: dummy_gpu_backend(),
-            resources: Default::default(),
-            fence_state: Arc::new(Mutex::new(Default::default())),
+            resources: BTreeMap::default(),
+            fence_state: Arc::new(Mutex::new(FenceState::default())),
             scanouts: Default::default(),
         }
     }

--- a/staging/vhost-device-gpu/src/virtio_gpu.rs
+++ b/staging/vhost-device-gpu/src/virtio_gpu.rs
@@ -390,6 +390,7 @@ impl RutabagaVirtioGpu {
     fn configure_rutabaga_builder(gpu_mode: GpuMode) -> RutabagaBuilder {
         let component = match gpu_mode {
             GpuMode::VirglRenderer => RutabagaComponentType::VirglRenderer,
+            #[cfg(feature = "gfxstream")]
             GpuMode::Gfxstream => RutabagaComponentType::Gfxstream,
         };
         RutabagaBuilder::new(component, 0)

--- a/staging/vhost-device-video/Cargo.toml
+++ b/staging/vhost-device-video/Cargo.toml
@@ -23,7 +23,7 @@ env_logger = "0.11"
 epoll = "4.3"
 num_enum = "0.7"
 log = "0.4"
-libc = "0.2.167"
+libc = "0.2.169"
 thiserror = "2.0"
 futures-executor = { version = "0.3", features = ["thread-pool"] }
 vhost = { version = "0.13", features = ["vhost-user-backend"] }

--- a/staging/vhost-device-video/Cargo.toml
+++ b/staging/vhost-device-video/Cargo.toml
@@ -23,7 +23,7 @@ env_logger = "0.11"
 epoll = "4.3"
 num_enum = "0.7"
 log = "0.4"
-libc = "0.2.164"
+libc = "0.2.167"
 thiserror = "2.0"
 futures-executor = { version = "0.3", features = ["thread-pool"] }
 vhost = { version = "0.13", features = ["vhost-user-backend"] }

--- a/staging/vhost-device-video/src/vhu_video.rs
+++ b/staging/vhost-device-video/src/vhu_video.rs
@@ -27,9 +27,9 @@ use crate::{vhu_video_thread::VhostUserVideoThread, video_backends};
 
 /// Virtio Video Feature bits
 const VIRTIO_VIDEO_F_RESOURCE_GUEST_PAGES: u16 = 0;
-/// Unsupported
-/// const VIRTIO_VIDEO_F_RESOURCE_NON_CONTIG: u16 = 1;
-/// const VIRTIO_VIDEO_F_RESOURCE_VIRTIO_OBJECT: u16 = 2;
+// Unsupported
+// const VIRTIO_VIDEO_F_RESOURCE_NON_CONTIG: u16 = 1;
+// const VIRTIO_VIDEO_F_RESOURCE_VIRTIO_OBJECT: u16 = 2;
 
 const COMMAND_Q: u16 = 0;
 const EVENT_Q: u16 = 1;

--- a/vhost-device-can/Cargo.toml
+++ b/vhost-device-can/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.11"
 log = "0.4"
 thiserror = "2.0"
 queues = "1.0.2"
-socketcan = "3.3.1"
+socketcan = "3.5.0"
 vhost = { version = "0.13", features = ["vhost-user-backend"] }
 vhost-user-backend = "0.17"
 virtio-bindings = "0.2.2"

--- a/vhost-device-console/Cargo.toml
+++ b/vhost-device-console/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 xen = ["vm-memory/xen", "vhost/xen", "vhost-user-backend/xen"]
 
 [dependencies]
-console = "0.15.7"
+console = "0.15.10"
 crossterm = "0.28.1"
 queues = "1.0.2"
 clap = { version = "4.5",  features = ["derive"] }

--- a/vhost-device-gpio/src/virtio_gpio.rs
+++ b/vhost-device-gpio/src/virtio_gpio.rs
@@ -5,8 +5,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
-/// Virtio specification definitions
-/// Virtio GPIO request types
+//! Virtio specification definitions
+
+// Virtio GPIO request types
 
 pub const VIRTIO_GPIO_MSG_GET_LINE_NAMES: u16 = 0x0001;
 pub const VIRTIO_GPIO_MSG_GET_DIRECTION: u16 = 0x0002;
@@ -15,12 +16,14 @@ pub const VIRTIO_GPIO_MSG_GET_VALUE: u16 = 0x0004;
 pub const VIRTIO_GPIO_MSG_SET_VALUE: u16 = 0x0005;
 pub const VIRTIO_GPIO_MSG_IRQ_TYPE: u16 = 0x0006;
 
-/// Direction types
+// Direction types
+
 pub const VIRTIO_GPIO_DIRECTION_NONE: u8 = 0x00;
 pub const VIRTIO_GPIO_DIRECTION_OUT: u8 = 0x01;
 pub const VIRTIO_GPIO_DIRECTION_IN: u8 = 0x02;
 
-/// Virtio GPIO IRQ types
+// Virtio GPIO IRQ types
+
 pub const VIRTIO_GPIO_IRQ_TYPE_NONE: u16 = 0x00;
 pub const VIRTIO_GPIO_IRQ_TYPE_EDGE_RISING: u16 = 0x01;
 pub const VIRTIO_GPIO_IRQ_TYPE_EDGE_FALLING: u16 = 0x02;

--- a/vhost-device-i2c/src/i2c.rs
+++ b/vhost-device-i2c/src/i2c.rs
@@ -56,8 +56,9 @@ pub(crate) enum Error {
     ParseFailure,
 }
 
-/// Linux I2C/SMBUS definitions
-/// IOCTL commands, refer Linux's Documentation/i2c/dev-interface.rst for further details.
+// Linux I2C/SMBUS definitions
+
+// IOCTL commands, refer Linux's Documentation/i2c/dev-interface.rst for further details.
 
 /// NOTE: Slave address is 7 or 10 bits, but 10-bit addresses are NOT supported!
 /// (due to code brokenness)
@@ -114,7 +115,6 @@ pub(crate) const I2C_M_RD: u16 = 0x0001; // read data, from slave to master
 /// and ACKed.  If this is the last message in a group, it is followed by
 /// a STOP.  Otherwise it is followed by the next @I2cMsg transaction
 /// segment, beginning with a (repeated) START.
-
 #[repr(C)]
 struct I2cMsg {
     addr: u16,

--- a/vhost-device-i2c/src/vhu_i2c.rs
+++ b/vhost-device-i2c/src/vhu_i2c.rs
@@ -71,7 +71,7 @@ impl convert::From<Error> for io::Error {
     }
 }
 
-/// I2C definitions from Virtio Spec
+// I2C definitions from Virtio Spec
 
 /// The final status written by the device
 const VIRTIO_I2C_MSG_OK: u8 = 0;

--- a/vhost-device-input/CHANGELOG.md
+++ b/vhost-device-input/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 ## Unreleased
 
-- First initial vhost-device-input daemon implementation.
-
 ### Added
 
 ### Changed
@@ -10,4 +8,8 @@
 ### Fixed
 
 ### Deprecated
+
+## v0.1.0
+
+First release
 

--- a/vhost-device-scmi/CHANGELOG.md
+++ b/vhost-device-scmi/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Added
 
+- [[#798]](https://github.com/rust-vmm/vhost-device/pull/798) scmi: extended sensor attributes support
+
 ### Changed
 
 ### Fixed

--- a/vhost-device-scmi/CHANGELOG.md
+++ b/vhost-device-scmi/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fixed
 
+- [[#798]](https://github.com/rust-vmm/vhost-device/pull/798) Fix the wrong value number of remaining sensor axis descriptor.
+
 ### Deprecated
 
 ## v0.3.0

--- a/vhost-device-scmi/Cargo.toml
+++ b/vhost-device-scmi/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5",  features = ["derive"] }
 env_logger = "0.11"
-itertools = "0.13"
+itertools = "0.14"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.13", features = ["vhost-user-backend"] }

--- a/vhost-device-scmi/src/devices/common.rs
+++ b/vhost-device-scmi/src/devices/common.rs
@@ -450,11 +450,11 @@ pub trait SensorT: Send {
                 if axis_desc_index >= n_sensor_axes {
                     return Result::Err(ScmiDeviceError::InvalidParameters);
                 }
-                let mut values = vec![MessageValue::Unsigned(n_sensor_axes - axis_desc_index)];
-                for i in axis_desc_index..n_sensor_axes {
-                    let mut description = self.axis_description(i);
-                    values.append(&mut description);
-                }
+                // Report only a single axis, in order to not exceed the descriptor size.
+                let num_axis_flags = 1 | ((n_sensor_axes - axis_desc_index - 1) << 26);
+                let mut values = vec![MessageValue::Unsigned(num_axis_flags)];
+                let mut description = self.axis_description(axis_desc_index);
+                values.append(&mut description);
                 Ok(values)
             }
             SENSOR_CONFIG_GET => self.config_get(),

--- a/vhost-device-scmi/src/devices/common.rs
+++ b/vhost-device-scmi/src/devices/common.rs
@@ -66,12 +66,12 @@ impl DeviceProperties {
         self.0.iter().map(|(n, _)| -> &str { n.as_str() }).collect()
     }
 
-    fn extra<'a>(&'a self, allowed: &[&'a str]) -> HashSet<&str> {
+    fn extra<'a>(&'a self, allowed: &[&'a str]) -> HashSet<&'a str> {
         let allowed_set: HashSet<&str> = HashSet::from_iter(allowed.iter().copied());
         self.names().difference(&allowed_set).copied().collect()
     }
 
-    fn missing<'a>(&'a self, required: &[&'a str]) -> HashSet<&str> {
+    fn missing<'a>(&'a self, required: &[&'a str]) -> HashSet<&'a str> {
         let required_set: HashSet<&str> = HashSet::from_iter(required.iter().copied());
         required_set.difference(&self.names()).copied().collect()
     }

--- a/vhost-device-scmi/src/scmi.rs
+++ b/vhost-device-scmi/src/scmi.rs
@@ -1377,17 +1377,18 @@ mod tests {
             MessageValue::Unsigned(0),
             MessageValue::Unsigned(axis_index),
         ];
-        let mut result = vec![MessageValue::Unsigned(n_axes - axis_index)];
-        for i in axis_index..n_axes {
-            let name = format!("acc_{}", char::from_u32('X' as u32 + i).unwrap()).to_string();
-            let mut description = vec![
-                MessageValue::Unsigned(i),
-                MessageValue::Unsigned(0),
-                MessageValue::Unsigned(u32::from(SENSOR_UNIT_METERS_PER_SECOND_SQUARED)),
-                MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
-            ];
-            result.append(&mut description);
-        }
+        // Each call will return only one descriptor to avoid exceeding the maximum length of the message
+        // and to inform about the number of the remaining sensor axis descriptions.
+        let num_axis_flags = 1 | (n_axes - axis_index - 1) << 26;
+        let mut result = vec![MessageValue::Unsigned(num_axis_flags)];
+        let name = format!("acc_{}", char::from_u32('X' as u32 + axis_index).unwrap()).to_string();
+        let mut description = vec![
+            MessageValue::Unsigned(axis_index),
+            MessageValue::Unsigned(0),
+            MessageValue::Unsigned(u32::from(SENSOR_UNIT_METERS_PER_SECOND_SQUARED)),
+            MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
+        ];
+        result.append(&mut description);
         test_message(
             SENSOR_PROTOCOL_ID,
             SENSOR_AXIS_DESCRIPTION_GET,

--- a/vhost-device-scmi/src/scmi.rs
+++ b/vhost-device-scmi/src/scmi.rs
@@ -1384,9 +1384,15 @@ mod tests {
         let name = format!("acc_{}", char::from_u32('X' as u32 + axis_index).unwrap()).to_string();
         let mut description = vec![
             MessageValue::Unsigned(axis_index),
-            MessageValue::Unsigned(0),
+            MessageValue::Unsigned(1 << 8),
             MessageValue::Unsigned(u32::from(SENSOR_UNIT_METERS_PER_SECOND_SQUARED)),
             MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
+            // Add extended attributes
+            MessageValue::Unsigned(0),
+            MessageValue::Signed(0),
+            MessageValue::Signed(i32::MIN),
+            MessageValue::Signed(-1i32),
+            MessageValue::Signed(i32::MAX),
         ];
         result.append(&mut description);
         test_message(

--- a/vhost-device-scmi/src/scmi.rs
+++ b/vhost-device-scmi/src/scmi.rs
@@ -468,11 +468,7 @@ impl HandlerMap {
                 let max_sensors_to_return = 256;
                 let sensors_to_return = min(n_sensors - first_index, max_sensors_to_return);
                 let last_non_returned_sensor = first_index + sensors_to_return;
-                let remaining_sensors = if n_sensors > last_non_returned_sensor {
-                    n_sensors - last_non_returned_sensor
-                } else {
-                    0
-                };
+                let remaining_sensors = n_sensors.saturating_sub(last_non_returned_sensor);
                 let mut values = vec![MessageValue::Unsigned(
                     sensors_to_return as u32 | (remaining_sensors as u32) << 16,
                 )];

--- a/vhost-device-sound/Cargo.toml
+++ b/vhost-device-sound/Cargo.toml
@@ -41,3 +41,4 @@ vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] 
 
 [target.'cfg(target_env = "gnu")'.dev-dependencies]
 rand = { version = "0.8.5" }
+rusty-fork = { version = "0.3.0" }

--- a/vhost-device-sound/Cargo.toml
+++ b/vhost-device-sound/Cargo.toml
@@ -38,3 +38,6 @@ rstest = "0.23.0"
 tempfile = "3.14"
 virtio-queue = { version = "0.14", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
+
+[target.'cfg(target_env = "gnu")'.dev-dependencies]
+rand = { version = "0.8.5" }

--- a/vhost-device-sound/src/audio_backends.rs
+++ b/vhost-device-sound/src/audio_backends.rs
@@ -54,7 +54,11 @@ pub fn alloc_audio_backend(
     match backend {
         BackendType::Null => Ok(Box::new(NullBackend::new(streams))),
         #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
-        BackendType::Pipewire => Ok(Box::new(PwBackend::new(streams))),
+        BackendType::Pipewire => {
+            Ok(Box::new(PwBackend::new(streams).map_err(|err| {
+                crate::Error::UnexpectedAudioBackendError(err.into())
+            })?))
+        }
         #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
         BackendType::Alsa => Ok(Box::new(AlsaBackend::new(streams))),
     }

--- a/vhost-device-sound/src/audio_backends.rs
+++ b/vhost-device-sound/src/audio_backends.rs
@@ -80,11 +80,14 @@ mod tests {
         }
         #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
         {
-            use pipewire::{test_utils::PipewireTestHarness, *};
+            use pipewire::{
+                test_utils::{try_backoff, PipewireTestHarness},
+                *,
+            };
 
             let _test_harness = PipewireTestHarness::new();
             let v = BackendType::Pipewire;
-            let value = alloc_audio_backend(v, Default::default()).unwrap();
+            let value = try_backoff(|| alloc_audio_backend(v, Default::default()), std::num::NonZeroU32::new(3)).expect("reached maximum retry count");
             assert_eq!(TypeId::of::<PwBackend>(), value.as_any().type_id());
         }
         #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]

--- a/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/vhost-device-sound/src/audio_backends/alsa.rs
@@ -654,7 +654,7 @@ impl AudioBackend for AlsaBackend {
             .write()
             .unwrap()
             .get_mut(id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(id))?
+            .ok_or(Error::StreamWithIdNotFound(id))?
             .state
             .stop()
         {

--- a/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/vhost-device-sound/src/audio_backends/alsa.rs
@@ -609,7 +609,7 @@ impl AudioBackend for AlsaBackend {
                     stream_id,
                     err
                 );
-                return Err(Error::UnexpectedAudioBackendError(err.to_string()));
+                return Err(Error::UnexpectedAudioBackendError(err.into()));
             }
         }
         self.senders[stream_id as usize].send(true).unwrap();
@@ -642,7 +642,7 @@ impl AudioBackend for AlsaBackend {
                     stream_id,
                     err
                 );
-                return Err(Error::UnexpectedAudioBackendError(err.to_string()));
+                return Err(Error::UnexpectedAudioBackendError(err.into()));
             }
         }
         Ok(())

--- a/vhost-device-sound/src/audio_backends/alsa/test_utils.rs
+++ b/vhost-device-sound/src/audio_backends/alsa/test_utils.rs
@@ -3,58 +3,31 @@
 
 use std::{
     path::PathBuf,
-    sync::{
-        atomic::{AtomicU8, Ordering},
-        Arc, Mutex, Once,
-    },
+    sync::{Arc, LazyLock, Mutex},
 };
 
 use tempfile::{tempdir, TempDir};
 
-static mut TEST_HARNESS: Option<AlsaTestHarness> = None;
-static INIT_ALSA_CONF: Once = Once::new();
+static TEST_HARNESS: LazyLock<AlsaTestHarness> = LazyLock::new(AlsaTestHarness::new);
 
 #[must_use]
-pub fn setup_alsa_conf() -> AlsaTestHarnessRef<'static> {
-    INIT_ALSA_CONF.call_once(||
-        // SAFETY:
-        // This is only called once, because of.. `Once`, so it's safe to
-        // access the static value mutably.
-        unsafe {
-            TEST_HARNESS = Some(AlsaTestHarness::new());
-        });
-    let retval = AlsaTestHarnessRef(
-        // SAFETY:
-        // The unsafe { } block is needed because TEST_HARNESS is a mutable static. The inner
-        // operations are protected by atomics.
-        unsafe { TEST_HARNESS.as_ref().unwrap() },
-    );
-    retval.0.inc_ref();
-    retval
+pub fn setup_alsa_conf() -> &'static AlsaTestHarness {
+    // Dereferencing is necessary to perform the LazyLock init fn
+    &TEST_HARNESS
 }
 
-/// The alsa test harness. It must only be constructed via
-/// `AlsaTestHarness::new()`.
-#[non_exhaustive]
+/// The alsa test harness.
+///
+/// It sets up the `ALSA_CONFIG_PATH` variable pointing to a configuration file
+/// inside a temporary directory. This way the tests won't mess with the host
+/// machine's devices.
 pub struct AlsaTestHarness {
-    pub tempdir: Arc<Mutex<Option<TempDir>>>,
-    pub conf_path: PathBuf,
-    pub ref_count: AtomicU8,
-}
-
-/// Ref counted alsa test harness ref.
-#[repr(transparent)]
-#[non_exhaustive]
-pub struct AlsaTestHarnessRef<'a>(&'a AlsaTestHarness);
-
-impl<'a> Drop for AlsaTestHarnessRef<'a> {
-    fn drop(&mut self) {
-        self.0.dec_ref();
-    }
+    tempdir: Arc<Mutex<Option<TempDir>>>,
+    conf_path: PathBuf,
 }
 
 impl AlsaTestHarness {
-    pub fn new() -> Self {
+    fn new() -> Self {
         let tempdir = tempdir().unwrap();
         let conf_path = tempdir.path().join("alsa.conf");
 
@@ -74,55 +47,20 @@ impl AlsaTestHarness {
         Self {
             tempdir: Arc::new(Mutex::new(Some(tempdir))),
             conf_path,
-            ref_count: 0.into(),
-        }
-    }
-
-    #[inline]
-    pub fn inc_ref(&self) {
-        let old_val = self.ref_count.fetch_add(1, Ordering::SeqCst);
-        assert!(
-            old_val != u8::MAX,
-            "ref_count overflowed on 8bits when increasing by 1"
-        );
-    }
-
-    #[inline]
-    pub fn dec_ref(&self) {
-        let old_val = self.ref_count.fetch_sub(1, Ordering::SeqCst);
-        if old_val == 1 {
-            let mut lck = self.tempdir.lock().unwrap();
-            println!(
-                "INFO: unsetting ALSA_CONFIG_PATH={} in PID {} and TID {:?}",
-                self.conf_path.display(),
-                std::process::id(),
-                std::thread::current().id()
-            );
-            std::env::remove_var("ALSA_CONFIG_PATH");
-            _ = lck.take();
         }
     }
 }
 
 impl Drop for AlsaTestHarness {
     fn drop(&mut self) {
-        let ref_count = self.ref_count.load(Ordering::SeqCst);
-        if ref_count != 0 {
-            println!(
-                "ERROR: ref_count is {ref_count} when dropping {}",
-                stringify!(AlsaTestHarness)
-            );
-        }
-        if self
-            .tempdir
-            .lock()
-            .map(|mut l| l.take().is_some())
-            .unwrap_or(false)
-        {
-            println!(
-                "ERROR: tempdir held a value when dropping {}",
-                stringify!(AlsaTestHarness)
-            );
-        }
+        let mut lck = self.tempdir.lock().unwrap();
+        println!(
+            "INFO: unsetting ALSA_CONFIG_PATH={} in PID {} and TID {:?}",
+            self.conf_path.display(),
+            std::process::id(),
+            std::thread::current().id()
+        );
+        std::env::remove_var("ALSA_CONFIG_PATH");
+        _ = lck.take();
     }
 }

--- a/vhost-device-sound/src/audio_backends/null.rs
+++ b/vhost-device-sound/src/audio_backends/null.rs
@@ -10,7 +10,7 @@ pub struct NullBackend {
 }
 
 impl NullBackend {
-    pub fn new(streams: Arc<RwLock<Vec<Stream>>>) -> Self {
+    pub const fn new(streams: Arc<RwLock<Vec<Stream>>>) -> Self {
         Self { streams }
     }
 }

--- a/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -195,7 +195,7 @@ impl AudioBackend for PwBackend {
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
+            .ok_or(Error::StreamWithIdNotFound(stream_id))?
             .state
             .prepare();
         if let Err(err) = prepare_result {
@@ -500,7 +500,7 @@ impl AudioBackend for PwBackend {
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
+            .ok_or(Error::StreamWithIdNotFound(stream_id))?
             .state
             .release();
         if let Err(err) = release_result {
@@ -529,7 +529,7 @@ impl AudioBackend for PwBackend {
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
+            .ok_or(Error::StreamWithIdNotFound(stream_id))?
             .state
             .start();
         if let Err(err) = start_result {
@@ -554,7 +554,7 @@ impl AudioBackend for PwBackend {
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
+            .ok_or(Error::StreamWithIdNotFound(stream_id))?
             .state
             .stop();
         if let Err(err) = stop_result {

--- a/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
 use std::{
+    convert::TryFrom,
     io::Read,
     path::Path,
     process::{Child, Command, Stdio},
+    thread::sleep,
+    time::{Duration, Instant},
 };
 
+use rand::distributions::Uniform;
 use tempfile::{tempdir, TempDir};
 
 /// Temporary Dbus session which is killed in drop().
@@ -80,13 +84,13 @@ impl PipewireTestHarness {
         println!("INFO: dbus_session_bus_address={}", dbus_session.address);
 
         println!("INFO: Wait for dbus to setup...");
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        sleep(Duration::from_secs(1));
 
         println!("INFO: Launch pipewire.");
         let pipewire_child = launch_pipewire(tempdir.path(), Path::new(&dbus_session.address))
             .expect("ERROR: Could not launch pipewire");
         println!("INFO: Wait for pipewire to setup...");
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        sleep(Duration::from_secs(1));
 
         std::env::set_var("DBUS_SESSION_BUS_ADDRESS", &dbus_session.address);
         std::env::set_var("XDG_RUNTIME_DIR", tempdir.path());
@@ -131,4 +135,69 @@ fn print_output(child: &mut Child, id: &'static str) -> Option<()> {
     }
 
     None
+}
+
+pub fn truncated_wait_delay<D: rand::distributions::Distribution<f32>, R: rand::Rng>(
+    slot_time: &Duration,
+    attempts_so_far: u32,
+    exponent_max: u32,
+    rng: &mut R,
+    distribution: &D,
+) -> Duration {
+    let attempts_so_far =
+        i32::try_from(attempts_so_far.clamp(0_u32, exponent_max)).unwrap_or(i32::MAX);
+    let position = distribution.sample(rng);
+    let max = 2_f32.powi(attempts_so_far) - 1.0_f32;
+    slot_time.mul_f32(position * max)
+}
+
+pub fn try_backoff<T, E: std::fmt::Display>(
+    closure: impl Fn() -> Result<T, E>,
+    max_retries: Option<std::num::NonZeroU32>,
+) -> Result<T, ()> {
+    const NO_DELAY: Duration = Duration::new(0, 0);
+
+    let max_retries: Option<u32> = max_retries.map(Into::into);
+    let mut iterations: u32 = 0;
+    let mut dur: Option<Duration> = None;
+    let mut rng = rand::thread_rng();
+
+    let distribution = Uniform::new(0.0_f32, 1.0_f32);
+
+    loop {
+        if max_retries.map_or(false, |max| iterations >= max) {
+            return Err(());
+        }
+
+        let start: Instant = Instant::now();
+        let result: Result<T, E> = closure();
+        let elapsed: Duration = start.elapsed();
+
+        iterations += 1;
+
+        match result {
+            Ok(v) => return Ok(v),
+            Err(err) => {
+                log::debug!("try_backoff: closured failed with {err}, will retry");
+            }
+        }
+
+        if let Some(dur_val) = &dur {
+            dur = Some((*dur_val * (iterations - 1) + elapsed) / iterations);
+        } else {
+            dur = Some(elapsed);
+        }
+
+        let delay: Duration = truncated_wait_delay(
+            dur.as_ref().unwrap_or(&NO_DELAY),
+            iterations,
+            10_u32,
+            &mut rng,
+            &distribution,
+        );
+
+        log::debug!("Sleeping for {}s", delay.as_secs_f64());
+
+        sleep(delay);
+    }
 }

--- a/vhost-device-sound/src/device.rs
+++ b/vhost-device-sound/src/device.rs
@@ -92,11 +92,11 @@ impl VhostUserSoundThread {
     ) -> IoResult<()> {
         let vring = &vrings
             .get(device_event as usize)
-            .ok_or_else(|| Error::HandleUnknownEvent(device_event))?;
+            .ok_or(Error::HandleUnknownEvent(device_event))?;
         let queue_idx = self
             .queue_indexes
             .get(device_event as usize)
-            .ok_or_else(|| Error::HandleUnknownEvent(device_event))?;
+            .ok_or(Error::HandleUnknownEvent(device_event))?;
         if self.event_idx {
             // vm-virtio's Queue implementation only checks avail_index
             // once, so to properly support EVENT_IDX we need to keep

--- a/vhost-device-sound/src/lib.rs
+++ b/vhost-device-sound/src/lib.rs
@@ -161,7 +161,7 @@ pub enum Error {
     #[error("Audio backend not supported")]
     AudioBackendNotSupported,
     #[error("Audio backend unexpected error: {0}")]
-    UnexpectedAudioBackendError(String),
+    UnexpectedAudioBackendError(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("Audio backend configuration not supported")]
     UnexpectedAudioBackendConfiguration,
     #[error("No memory configured")]

--- a/vhost-device-sound/src/stream.rs
+++ b/vhost-device-sound/src/stream.rs
@@ -266,7 +266,7 @@ impl std::fmt::Debug for Request {
 }
 
 impl Request {
-    pub fn new(len: usize, message: Arc<IOMessage>, direction: Direction) -> Self {
+    pub const fn new(len: usize, message: Arc<IOMessage>, direction: Direction) -> Self {
         Self {
             pos: 0,
             len,

--- a/vhost-device-vsock/Cargo.toml
+++ b/vhost-device-vsock/Cargo.toml
@@ -30,7 +30,7 @@ vm-memory = "0.16.1"
 vmm-sys-util = "0.12"
 figment = { version = "0.10.19", features = ["yaml"] }
 vsock = { version = "0.5.0", optional = true }
-libc = { version = "0.2.164", optional = true }
+libc = { version = "0.2.167", optional = true }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/vhost-device-vsock/Cargo.toml
+++ b/vhost-device-vsock/Cargo.toml
@@ -30,7 +30,7 @@ vm-memory = "0.16.1"
 vmm-sys-util = "0.12"
 figment = { version = "0.10.19", features = ["yaml"] }
 vsock = { version = "0.5.0", optional = true }
-libc = { version = "0.2.167", optional = true }
+libc = { version = "0.2.169", optional = true }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/vhost-device-vsock/README.md
+++ b/vhost-device-vsock/README.md
@@ -241,6 +241,40 @@ application running on the host. Assuming the applications listening on port 900
 now run the applications that connect to port 9001 and 9002 (you need to modify the CID they connect to be the host CID i.e. 1)
 on the host machine.
 
+## Testing
+
+This crate contains several tests that can be run with `cargo test`.
+
+If `backend_vsock` feature is enabled (true by default), some of the tests use
+the AF_VSOCK loopback address [CID = 1] to run the tests, so you must have
+loaded the kernel module that handles it (`modprobe vsock_loopback`).
+
+Otherwise you may experience the following failures:
+```
+...
+test thread_backend::tests::test_vsock_thread_backend_vsock ... FAILED
+...
+test vhu_vsock_thread::tests::test_vsock_thread_vsock_backend ... FAILED
+
+failures:
+
+
+---- thread_backend::tests::test_vsock_thread_backend_vsock stdout ----
+thread 'thread_backend::tests::test_vsock_thread_backend_vsock' panicked at vhost-device-vsock/src/thread_backend.rs:607:84:
+This test uses VMADDR_CID_LOCAL, so the vsock_loopback kernel module must be loaded: Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" }
+
+---- vhu_vsock_thread::tests::test_vsock_thread_vsock_backend stdout ----
+thread 'vhu_vsock_thread::tests::test_vsock_thread_vsock_backend' panicked at vhost-device-vsock/src/vhu_vsock_thread.rs:1044:84:
+This test uses VMADDR_CID_LOCAL, so the vsock_loopback kernel module must be loaded: Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" }
+
+failures:
+    thread_backend::tests::test_vsock_thread_backend_vsock
+    vhu_vsock_thread::tests::test_vsock_thread_vsock_backend
+```
+
+With the `vsock_loopback` kernel module loaded in your system, all the tests
+should pass.
+
 ## License
 
 This project is licensed under either of

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -518,7 +518,7 @@ mod tests {
     use tempfile::tempdir;
     use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
     #[cfg(feature = "backend_vsock")]
-    use vsock::{VsockListener, VMADDR_CID_ANY};
+    use vsock::{VsockListener, VMADDR_CID_ANY, VMADDR_CID_LOCAL};
 
     const DATA_LEN: usize = 16;
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
@@ -606,7 +606,7 @@ mod tests {
     fn test_vsock_thread_backend_vsock() {
         let _listener = VsockListener::bind_with_cid_port(VMADDR_CID_ANY, VSOCK_PEER_PORT).unwrap();
         let backend_info = BackendType::Vsock(VsockProxyInfo {
-            forward_cid: 1,
+            forward_cid: VMADDR_CID_LOCAL,
             listen_ports: vec![],
         });
 

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -604,6 +604,10 @@ mod tests {
     #[cfg(feature = "backend_vsock")]
     #[test]
     fn test_vsock_thread_backend_vsock() {
+        VsockListener::bind_with_cid_port(VMADDR_CID_LOCAL, libc::VMADDR_PORT_ANY).expect(
+            "This test uses VMADDR_CID_LOCAL, so the vsock_loopback kernel module must be loaded",
+        );
+
         let _listener = VsockListener::bind_with_cid_port(VMADDR_CID_ANY, VSOCK_PEER_PORT).unwrap();
         let backend_info = BackendType::Vsock(VsockProxyInfo {
             forward_cid: VMADDR_CID_LOCAL,

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -49,28 +49,24 @@ pub(crate) const VSOCK_HOST_CID: u64 = 2;
 /// Connection oriented packet
 pub(crate) const VSOCK_TYPE_STREAM: u16 = 1;
 
-/// Vsock packet operation ID
-
-/// Connection request
+/// Vsock packet operation ID - Connection request
 pub(crate) const VSOCK_OP_REQUEST: u16 = 1;
-/// Connection response
+/// Vsock packet operation ID - Connection response
 pub(crate) const VSOCK_OP_RESPONSE: u16 = 2;
-/// Connection reset
+/// Vsock packet operation ID - Connection reset
 pub(crate) const VSOCK_OP_RST: u16 = 3;
-/// Shutdown connection
+/// Vsock packet operation ID - Shutdown connection
 pub(crate) const VSOCK_OP_SHUTDOWN: u16 = 4;
-/// Data read/write
+/// Vsock packet operation ID - Data read/write
 pub(crate) const VSOCK_OP_RW: u16 = 5;
-/// Flow control credit update
+/// Vsock packet operation ID - Flow control credit update
 pub(crate) const VSOCK_OP_CREDIT_UPDATE: u16 = 6;
-/// Flow control credit request
+/// Vsock packet operation ID - Flow control credit request
 pub(crate) const VSOCK_OP_CREDIT_REQUEST: u16 = 7;
 
-/// Vsock packet flags
-
-/// VSOCK_OP_SHUTDOWN: Packet sender will receive no more data
+/// Vsock packet flags - `VSOCK_OP_SHUTDOWN`: Packet sender will receive no more data
 pub(crate) const VSOCK_FLAGS_SHUTDOWN_RCV: u32 = 1;
-/// VSOCK_OP_SHUTDOWN: Packet sender will send no more data
+/// Vsock packet flags - `VSOCK_OP_SHUTDOWN`: Packet sender will send no more data
 pub(crate) const VSOCK_FLAGS_SHUTDOWN_SEND: u32 = 2;
 
 // Queue mask to select vrings.

--- a/vhost-device-vsock/src/vhu_vsock_thread.rs
+++ b/vhost-device-vsock/src/vhu_vsock_thread.rs
@@ -1041,6 +1041,10 @@ mod tests {
     #[cfg(feature = "backend_vsock")]
     #[test]
     fn test_vsock_thread_vsock_backend() {
+        VsockListener::bind_with_cid_port(VMADDR_CID_LOCAL, libc::VMADDR_PORT_ANY).expect(
+            "This test uses VMADDR_CID_LOCAL, so the vsock_loopback kernel module must be loaded",
+        );
+
         let groups: Vec<String> = vec![String::from("default")];
         let cid_map: Arc<RwLock<CidMap>> = Arc::new(RwLock::new(HashMap::new()));
 

--- a/vhost-device-vsock/src/vhu_vsock_thread.rs
+++ b/vhost-device-vsock/src/vhu_vsock_thread.rs
@@ -816,7 +816,7 @@ mod tests {
     use vm_memory::GuestAddress;
     use vmm_sys_util::eventfd::EventFd;
     #[cfg(feature = "backend_vsock")]
-    use vsock::VsockStream;
+    use vsock::{VsockStream, VMADDR_CID_LOCAL};
 
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
 
@@ -1046,7 +1046,7 @@ mod tests {
 
         let t = VhostUserVsockThread::new(
             BackendType::Vsock(VsockProxyInfo {
-                forward_cid: 1,
+                forward_cid: VMADDR_CID_LOCAL,
                 listen_ports: vec![9003, 9004],
             }),
             3,
@@ -1063,8 +1063,8 @@ mod tests {
 
         t.mem = Some(mem.clone());
 
-        let mut vs1 = VsockStream::connect_with_cid_port(1, 9003).unwrap();
-        let mut vs2 = VsockStream::connect_with_cid_port(1, 9004).unwrap();
+        let mut vs1 = VsockStream::connect_with_cid_port(VMADDR_CID_LOCAL, 9003).unwrap();
+        let mut vs2 = VsockStream::connect_with_cid_port(VMADDR_CID_LOCAL, 9004).unwrap();
         t.process_backend_evt(EventSet::empty());
 
         vs1.write_all(b"some data").unwrap();


### PR DESCRIPTION
Add command line arguments for configuring which capsets and features are enabled when configuring Rutabaga. Since we now specify the capsets explicitly we can drop the MAX_NUM_CAPSETS constant and fix the TODO.

If the user selects virglrender the capsets are configururation is suitable for running virgl and venus (Vulkan) Linux guests. If the user select gfxstream then by default only vulkan is enabled.

`--help` output:
```
A virtio-gpu device using the vhost-user protocol.

Usage: vhost-device-gpu [OPTIONS] --socket-path <SOCKET> --gpu-mode <GPU_MODE>

Options:
  -s, --socket-path <SOCKET>
          vhost-user Unix domain socket

  -g, --gpu-mode <GPU_MODE>
          The mode specifies which backend implementation to use
          
          [possible values: virgl-renderer, gfxstream]

  -c, --capset <CAPSET>
          Comma separated list of enabled capsets

          Possible values:
          - virgl:              [virglrenderer] The virgl capset, superseded by Virgl2
          - virgl2:             [virglrenderer] OpenGL implementation
          - gfxstream-vulkan:   [gfxstream] Vulkan implementation
          - venus:              [virglrenderer] Vulkan implementation
          - drm:                [virglrenderer] unsuported/experimental: DRM native context support
          - gfxstream-magma:    [gfxstream] unsuported/experimental
          - gfxstream-gles:     [gfxstream] unsuported/experimental: OpenGL ES implementation
          - gfxstream-composer: [gfxstream] unsuported/experimental

      --use-egl <USE_EGL>
          Enable backend to use EGL
          
          [default: true]
          [possible values: true, false]

      --use-glx <USE_GLX>
          Enable backend to use GLX
          
          [default: false]
          [possible values: true, false]

      --use-gles <USE_GLES>
          Enable backend to use GLES
          
          [default: true]
          [possible values: true, false]

      --use-surfaceless <USE_SURFACELESS>
          Enable surfaceless backend option
          
          [default: true]
          [possible values: true, false]

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```